### PR TITLE
Should´ve used sudo su

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ If you want to have your logs written to a file:
 
 If you want to be able to close your terminal and you don't use screen:
 
-    sudo ./cjdroute < cjdroute.conf > /dev/null &
+    sudo su
+    ./cjdroute < cjdroute.conf > /dev/null &
 
 NOTE: when you use `&`, remember that you will have cjdroute processes running in the background
 if you are having problems use `killall cjdroute` to return to sanity. Use `pgrep cjdroute` or `top` to see if it running.


### PR DESCRIPTION
Sudo does not work on a single line with `&`
Or it becomes ugly as `echo <password> | sudo -S`

Didn´t test it properly before.
Already had a sudo sessions and didn´t need to enter my password i guess
