### PR TITLE
Updated cjdnslog to call python2 for improved cross-system compatibility

### DIFF
--- a/contrib/python/cjdnslog
+++ b/contrib/python/cjdnslog
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # You may redistribute this program and/or modify it under the terms of
 # the GNU General Public License as published by the Free Software Foundation,
 # either version 3 of the License, or (at your option) any later version.


### PR DESCRIPTION
cjdnslog now calls /usr/bin/python2 rather than /usr/bin/python
