### PR TITLE
Detecting unresponsive peers w/out switch label

### DIFF
--- a/net/DefaultInterfaceController.c
+++ b/net/DefaultInterfaceController.c
@@ -16,6 +16,7 @@
 #include "net/DefaultInterfaceController.h"
 #include "memory/Allocator.h"
 #include "net/SwitchPinger.h"
+#include "util/Base32.h"
 #include "util/Bits.h"
 #include "util/Time.h"
 #include "util/Timeout.h"


### PR DESCRIPTION
Uses the public key to identify unresponsive peers, instead of the switch label, so a script can determine which peer they are.
