### PR TITLE
Linux setsid() in process spawner

### DIFF
--- a/util/Process_Linux.c
+++ b/util/Process_Linux.c
@@ -42,6 +42,7 @@ int Process_spawn(char* binaryPath, char** args)
         }
         argv[0] = binaryPath;
         // Goodbye :)
+        setsid();
         execvp(binaryPath, argv);
         _exit(72);
     }


### PR DESCRIPTION
Avoids issues starting cjdns using cjdroute2 directly in an ssh command line (may still require -t for this to work, but with this it actually works ;)
