### PR TITLE
cjdns.sh: Add status command

### DIFF
--- a/scripts/cjdns.sh
+++ b/scripts/cjdns.sh
@@ -24,6 +24,9 @@
 # Stop cjdns if it's currently running (and set the above cronjob not to restart failed processes):
 #  ./cjdns.sh stop
 #
+# Check whether cjdns is currently running:
+#  ./cjdns.sh status
+#
 # Restart cjdns after upgrades and changes to the config:
 #  ./cjdns.sh restart
 ##
@@ -57,6 +60,18 @@ start()
     if [ $? -gt 0 ]; then return 1; fi
 }
 
+status()
+{
+    echo -n "* cjdns is "
+    if [ -z "$PID" ]; then
+        echo "not running"
+        exit 1
+    else
+        echo "running"
+        exit 0
+    fi
+}
+
 case "$1" in
     "start" )
         start
@@ -67,6 +82,9 @@ case "$1" in
         ;;
     "stop" )
         stop
+        ;;
+    "status" )
+        status
         ;;
     "check" )
         ps aux | grep -v 'grep' | grep 'cjdns core' > /dev/null 2>/dev/null || start


### PR DESCRIPTION
The check command is the closest available to check whether cjdns is
running. However, it has the side effect of starting cjdns if it is not
running.

Add the `status` command to report whether cjdns is running. This is
similar to a lot of init.d scripts for services. If cjdns is running, an
exit code of 0 will be returned. Otherwise an exit code of 1 is
returned.

```
$ ./scripts/cjdns.sh status
* cjdns is running
```

The `check` command could be refactored to use "status", however I don't know if there's a specific reason for using `ps | grep` instead of `pidof`. It seems the grep is more specific (looks for `cjdns core`).
