### PR TITLE
Change the JSON de-serialization parseString to use heap allocation

### DIFF
--- a/benc/serialization/json/JsonBencSerializer.c
+++ b/benc/serialization/json/JsonBencSerializer.c
@@ -104,31 +104,42 @@ static inline int parseString(const struct Reader* reader,
                               const struct Allocator* allocator,
                               String** output)
 {
-    #define BUFF_SZ (1<<20)
+    #define BUFF_SZ (1<<8)
+    #define BUFF_MAX (1<<20)
 
-    uint8_t buffer[BUFF_SZ];
+    int curSize = BUFF_SZ;
+    struct Allocator* localAllocator = allocator->child(allocator);
+    uint8_t* buffer = localAllocator->malloc(curSize, localAllocator);
     if (readUntil('"', reader) || reader->read(buffer, 1, reader)) {
         printf("Unterminated string\n");
+        localAllocator->free(localAllocator);
         return OUT_OF_CONTENT_TO_READ;
     }
-    for (int i = 0; i < BUFF_SZ - 1; i++) {
+    for (int i = 0; i < BUFF_MAX - 1; i++) {
         if (buffer[i] == '\\') {
             // \x01 (skip the x)
             reader->skip(1, reader);
             uint8_t hex[2];
             if (reader->read((char*)hex, 2, reader)) {
                 printf("Unexpected end of input parsing escape sequence\n");
+                localAllocator->free(localAllocator);
                 return OUT_OF_CONTENT_TO_READ;
             }
             int byte = Hex_decodeByte(hex[0], hex[1]);
             if (byte == -1) {
                 printf("Invalid escape \"%c%c\" after \"%.*s\"\n",hex[0],hex[1],i+1,buffer);
+                localAllocator->free(localAllocator);
                 return UNPARSABLE;
             }
             buffer[i] = (uint8_t) byte;
         } else if (buffer[i] == '"') {
             *output = String_newBinary((char*)buffer, i, allocator);
+            localAllocator->free(localAllocator);
             return 0;
+        }
+        if (i == curSize - 1) {
+            curSize <<= 1;
+            buffer = localAllocator->realloc(buffer, curSize, localAllocator);
         }
         if (reader->read(buffer + i + 1, 1, reader)) {
             if (i+1 <= 20) {
@@ -136,14 +147,17 @@ static inline int parseString(const struct Reader* reader,
             } else {
                 printf("Unterminated string starting with \"%.*s...\"\n", 20, buffer);
             }
+            localAllocator->free(localAllocator);
             return OUT_OF_CONTENT_TO_READ;
         }
     }
 
     printf("Maximum string length of %d bytes exceeded.\n",BUFF_SZ);
+    localAllocator->free(localAllocator);
     return UNPARSABLE;
 
     #undef BUFF_SZ
+    #undef BUFF_MAX
 }
 
 /** @see BencSerializer.h */


### PR DESCRIPTION
This changeset causes the JSON de-serialization to use a doubling heap allocation (starting with 256 bytes, doubling up to 1MB as necessary) to parse strings.  The old code uses a 1MB buffer on the stack which, if parseString is inlined, rapidly causes the stack to blow.  (It is inlined on my OS X Snow Leopard machine).

I am not completely confident that my allocator usage is kosher.  If it isn't, let me know and I'll find another solution.

Simply changing the buffer size from 1<<20 to 1<<16 fixes this problem for me; however, that is a data-dependent fix.  This fix should be more robust.
