### PR TITLE
Update admin/angel/cjdroute2.c

### DIFF
--- a/admin/angel/cjdroute2.c
+++ b/admin/angel/cjdroute2.c
@@ -169,7 +169,7 @@ static int genconf(struct Random* rand)
            "    \"authorizedPasswords\":\n"
            "    [\n"
            "        // A unique string which is known to the client and server.\n"
-           "        {\"password\": \"%s\"},\n", password);
+           "        {\"password\": \"%s\"}\n", password);
     printf("\n"
            "        // More passwords should look like this.\n"
            "        // {\"password\": \"%s\"},\n", password2);


### PR DESCRIPTION
comma after the default autorizedPassword prevents the config from being valid JSON. This broke cjconf-print and all the utilities that relied on it.
