### PR TITLE
Changed wording on default config

### DIFF
--- a/admin/angel/cjdroute2.c
+++ b/admin/angel/cjdroute2.c
@@ -176,10 +176,11 @@ static int genconf(struct Random* rand)
     printf("        // {\"password\": \"%s\"},\n", password3);
     printf("        // {\"password\": \"%s\"},\n", password4);
     printf("\n"
-           "        // These are your connection credentials\n"
-           "        // for people connecting to you with your default password.\n"
-           "        // adding more passwords for different users is advisable\n"
-           "        // so that leaks can be isolated.\n"
+           "        // Below is an example of your connection credentials\n"
+           "        // that you can give to other people so they can connect\n"
+           "        // to you using your default password (from above) \n"
+           "        // Adding a unique password for each user is advisable\n"
+           "        // so that leaks can be isolated. \n"
            "        //\n"
            "        // \"your.external.ip.goes.here:%u\":{", port);
     printf("\"password\":\"%s\",", password);


### PR DESCRIPTION
An IRC user thought the example connection setting block that you share with users was supposed to be enabled and that it would allow people to connect to him. Hopefully this will prevent the confusion.
