### PR TITLE
Map.h compare function fix

### DIFF
--- a/util/Map.h
+++ b/util/Map.h
@@ -53,18 +53,7 @@
         // Get the last 4 bytes of the key by default.
         static inline int Map_FUNCTION(compare)(Map_KEY_TYPE* keyA, Map_KEY_TYPE* keyB)
         {
-            uint32_t* kA = (uint32_t*) keyA;
-            uint32_t* kB = (uint32_t*) keyB;
-            for (int i = 0; i < (int)(sizeof(Map_KEY_TYPE) / 4); i++) {
-                if (kA[i] == kB[i]) {
-                    continue;
-                } else if (kA[i] < kB[i]) {
-                    return -1;
-                } else {
-                    return 1;
-                }
-            }
-            return 0;
+            return Bits_memcmp(keyA, keyB, sizeof(Map_KEY_TYPE));
         }
     #endif
 #endif


### PR DESCRIPTION
This resolves gcc4.4+ compilation issues with -Werror in Map.h by removing the aliasing, and in fact, just calling memcmp() for the compare function.
