### PR TITLE
Allow build without KERN_RANDOM/RANDOM_UUID

### DIFF
--- a/crypto/random/seed/LinuxRandomUuidSysctlRandomSeed.c
+++ b/crypto/random/seed/LinuxRandomUuidSysctlRandomSeed.c
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <sys/sysctl.h>
 
+#if defined(KERN_RANDOM) && defined(RANDOM_UUID)
 static int getUUID(uint64_t output[2])
 {
     int mib[] = { CTL_KERN, KERN_RANDOM, RANDOM_UUID };
@@ -41,6 +42,13 @@ static int get(struct RandomSeed* randomSeed, uint64_t output[8])
     }
     return 0;
 }
+
+#else
+static int get(struct RandomSeed* randomSeed, uint64_t output[8])
+{
+    return -1;
+}
+#endif
 
 struct RandomSeed* LinuxRandomUuidSysctlRandomSeed_new(struct Allocator* alloc)
 {


### PR DESCRIPTION
This allows building on systems where KERN_RANDOM/RANDOM_UUID are undefined. See #181
