### PR TITLE
Fixes a compilation issue on MacOSX.

### DIFF
--- a/crypto/random/seed/DevUrandomRandomSeed.c
+++ b/crypto/random/seed/DevUrandomRandomSeed.c
@@ -27,7 +27,7 @@
 
 static int get(struct RandomSeed* randomSeed, uint64_t output[8])
 {
-    Bits_memset(output, 0, sizeof(output));
+    Bits_memset(output, 0, sizeof(*output));
     int fd = -1;
     int tries = 0;
     while ((fd = open("/dev/urandom", O_RDONLY, 0)) < 0) {
@@ -38,7 +38,7 @@ static int get(struct RandomSeed* randomSeed, uint64_t output[8])
     }
     tries = 0;
     uint8_t* buff = (uint8_t*) output;
-    int count = sizeof(output);
+    int count = sizeof(*output);
     while (count > 0) {
         int r = read(fd, buff, count);
         if (r < 1) {
@@ -52,7 +52,7 @@ static int get(struct RandomSeed* randomSeed, uint64_t output[8])
         count -= r;
     }
     close(fd);
-    if (count == 0 && !Bits_isZero(output, sizeof(output))) {
+    if (count == 0 && !Bits_isZero(output, sizeof(*output))) {
         return 0;
     }
     return -1;


### PR DESCRIPTION
The issue appears with -Werror applied, might need to be handled
for other platforms, but I haven't heard of any issues with them.

error: sizeof on array function parameter will return size of 'uint64_t *'
      (aka 'unsigned long long *') instead of 'uint64_t [8]' [-Werror,-Wsizeof-array-argument]

The reason it may cause issues on other platforms is that the pointers may not have a 64bit width in some cases so even on platforms where this doesn't throw an error it may not always resolve to the expected 8.
