### PR TITLE
FreeBSD libuv fix

### DIFF
--- a/cmake/modules/FindLibuv.cmake
+++ b/cmake/modules/FindLibuv.cmake
@@ -30,6 +30,13 @@ if (NOT LIBUV_FOUND)
                 ${CMAKE_THREAD_LIBS_INIT}
                 ${CORE_SERVICES_LIB}
             )
+        elseif (FREEBSD)
+            set_property(TARGET uv PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES
+                ${SOCKET_LIBRARIES}
+                ${CLOCK_GETTIME_LIBRARIES}
+                ${CMAKE_THREAD_LIBS_INIT}
+                kvm
+            )
         else ()
             set_property(TARGET uv PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES
                 ${SOCKET_LIBRARIES}


### PR DESCRIPTION
This patch allows a build with NO_WERROR on FreeBSD. Tons of test errors still, but it compiles :\
