### PR TITLE
Adjust startup script to not rely on pidof

### DIFF
--- a/scripts/cjdns.sh
+++ b/scripts/cjdns.sh
@@ -56,8 +56,11 @@ stop()
 
 start()
 {
-    $CJDROUTE < $CONF 2>&1 >> $LOGTO &
-    if [ $? -gt 0 ]; then return 1; fi
+    $CJDROUTE < $CONF &>> $LOGTO
+    if [ $? -gt 0 ]; then
+        echo "Failed to start. (CJDNS already running?)"
+        return 1
+    fi
 }
 
 status()


### PR DESCRIPTION
Evidently, pidof is not available on certain Mac systems. This commit
switches to pgrep with arguments such that it will only match the actual
cjdns process, and not the script itself, as was problematic in certain
other implementations.

Where $CJDNS is the path to the CJDNS executable:

```
pgrep -d " " -f "$CJDNS"
```

This will output a space-delimited list of process IDs matching the path
to the CJDNS executable. This could be robustified (but perhaps broken
in future versions) by adding [angel|core] to the regex as follows.

```
pgrep -d " " -f "$CJDNS [angel|core]"
```
