### PR TITLE
Fix build failure on Mac OS 10.6.8

### DIFF
--- a/crypto/random/seed/AppleSecRandomCopyBytesRandomSeed.c
+++ b/crypto/random/seed/AppleSecRandomCopyBytesRandomSeed.c
@@ -15,7 +15,11 @@
 
 #include "crypto/random/seed/AppleSecRandomCopyBytesRandomSeed.h"
 
-#ifdef OSX
+#ifdef __APPLE__
+#include <Availability.h>
+#endif
+
+#if __OSX_AVAILABLE_STARTING(__MAC_10_7,__IPHONE_2_0)
 #include <Security/SecRandom.h>
 #include <inttypes.h>
 


### PR DESCRIPTION
This fix disables SecRandomCopyBytes in OSX <10.7, to [allow it to build](https://github.com/cjdelisle/cjdns/issues/199) in those environments.

SecRandomCopyBytes was introduced in OSX 10.7 [Lion](http://developer.apple.com/library/mac/#releasenotes/General/MacOSXLionAPIDiffs/Security.html) and in iOS.
It is useful on iOS since /dev/random is outside the sandbox. According to the [API docs](http://developer.apple.com/library/ios/#documentation/Security/Reference/RandomizationReference/Reference/reference.html), it just reads from /dev/random, so it should be okay for Snow Leopard to do without it.
