### PR TITLE
prevent system cmake use if version 2.8.11 or above

### DIFF
--- a/do
+++ b/do
@@ -40,7 +40,7 @@ if [ -f cmake-build/bin/cmake ]; then
     CMAKE=`pwd`/cmake-build/bin/cmake
 fi
 
-[ ${CMAKE} ] && ${CMAKE} --version | grep '2.8.\([2-9]\|1[0-9]\)' ||
+[ ${CMAKE} ] && ${CMAKE} --version | grep '2.8.\([2-9]\|10\)' ||
 while true; do
     [ -d cmake-build ] && rm -r cmake-build
     mkdir cmake-build


### PR DESCRIPTION
Tweaks the do script so it doesn't skip the cmake download if the version installed is 2.8.11 or above
