### PR TITLE
Tweak the cjdns.sh stop function to work correctly

### DIFF
--- a/scripts/cjdns.sh
+++ b/scripts/cjdns.sh
@@ -46,7 +46,7 @@ if [ -z "$CONF" ]; then CONF="${CJDPATH}cjdroute.conf"; fi
 # path ot the log file.
 if [ -z "$LOGTO" ]; then LOGTO="/dev/null"; fi
 
-PID=$(pgrep -d " " -f "$CJDNS")
+PID=$(pgrep -d " " -f "$CJDROUTE")
 
 stop()
 {


### PR DESCRIPTION
Currently the PID variable in cjdns.sh is found using the CJDNS variable, which points to the cjdns executable, but the process is listed using the cjdroute executable and so the script should be using the CJDROUTE variable to find it. This pull request is to fix that discrepancy.
