### PR TITLE
Make cjdns.sh do more, suck less

### DIFF
--- a/scripts/cjdns.sh
+++ b/scripts/cjdns.sh
@@ -81,7 +81,7 @@ update()
 {
 cd $CJDPATH/cjdns
 git pull
-./do
+./do || echo "Failed to update!" && exit 1
 echo "* Update complete, restarting cjdns"
 stop
 start


### PR DESCRIPTION
- Loads `/etc/defaults/cjdns` if it exists so I can change config stuff. Apparently this is a debian thing, so where should it look instead?
- Adds an "update" option, which just pulls the latest cjdns from git, rebuilds and restarts
- Fixed issue caused by merging cjdns and cjdroute
- Removed `$LOGTO`, as only basic startup information is dumped to stdout now
