### PR TITLE
Normalize sockaddr on BSD and Darwin.

### DIFF
--- a/util/events/libuv/UDPAddrInterface.c
+++ b/util/events/libuv/UDPAddrInterface.c
@@ -142,6 +142,7 @@ static void incoming(uv_udp_t* handle,
         m->capacity = buf.len;
         m->bytes = (uint8_t*)buf.base;
         m->alloc = alloc;
+        Sockaddr_normalizeNative(addr);
         Message_push(m, addr, context->pub.addr->addrLen - 8);
         Message_push(m, &context->pub.addr->addrLen, 8);
         Interface_receiveMessage(&context->pub.generic, m);

--- a/util/platform/Sockaddr.c
+++ b/util/platform/Sockaddr.c
@@ -75,6 +75,7 @@ struct Sockaddr* Sockaddr_fromNative(const void* ss, int addrLen, struct Allocat
     struct Sockaddr_pvt* out = Allocator_malloc(alloc, addrLen + Sockaddr_OVERHEAD);
     Bits_memcpy(&out->ss, ss, addrLen);
     out->pub.addrLen = addrLen + Sockaddr_OVERHEAD;
+    Sockaddr_normalizeNative(&out->ss);
     return &out->pub;
 }
 
@@ -287,4 +288,11 @@ struct Sockaddr* Sockaddr_fromBytes(const uint8_t* bytes, int addrFamily, struct
     Bits_memcpy(&out->ss, &ss, addrLen);
     out->pub.addrLen = addrLen + Sockaddr_OVERHEAD;
     return &out->pub;
+}
+
+void Sockaddr_normalizeNative(void* nativeSockaddr)
+{
+#if defined(BSD) || defined(Darwin)
+    ((struct sockaddr*)nativeSockaddr)->sa_len = 0;
+#endif
 }

--- a/util/platform/Sockaddr.h
+++ b/util/platform/Sockaddr.h
@@ -123,4 +123,9 @@ struct Sockaddr* Sockaddr_fromBytes(const uint8_t* bytes, int addrFamily, struct
  */
 struct Sockaddr* Sockaddr_clone(const struct Sockaddr* addr, struct Allocator* alloc);
 
+/**
+ * Normalize inconsistent native sockaddr implementations
+ */
+void Sockaddr_normalizeNative(void* nativeSockaddr);
+
 #endif


### PR DESCRIPTION
Fix bug involving comparing sockaddr structs. Discussion on #216.
