### PR TITLE
Fixed i_am_stupid.sh so it finds the PID correctly

### DIFF
--- a/contrib/bash/i_am_stupid.sh
+++ b/contrib/bash/i_am_stupid.sh
@@ -36,7 +36,7 @@ then
   exit 1
 fi
 
-PIDS="`pidof cjdns`"
+PIDS="`pidof cjdroute`"
 if [ "$PIDS" == "" ]
 then
   echo "no cjdns procs running. Dispair! All hope is lost. Unable to help. RIP cjdroute.conf"


### PR DESCRIPTION
i_am_stupid.sh uses 'cjdroute' instead of 'cjdns' when finding the PID
