### PR TITLE
Add Upstart script to contrib

### DIFF
--- a/contrib/upstart/cjdns.conf
+++ b/contrib/upstart/cjdns.conf
@@ -1,0 +1,30 @@
+description "cjdns startup script"
+
+author "Sergey Davidoff <shnatsel@gmail.com>"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [!2345]
+
+expect daemon
+
+pre-start script
+    if ! [ -e /etc/cjdroute.conf ]; then
+        touch /etc/cjdroute.conf
+        chmod 600 /etc/cjdroute.conf
+        /usr/bin/cjdroute --genconf > /etc/cjdroute.conf
+        echo 'WARNING: a new configuration file has been generated.'
+    fi
+    # If you need a non-standard setup, as described in
+    # https://github.com/cjdelisle/cjdns#non-standard-setups,
+    # you should add the commands to be run on every boot here.
+    # You'll also have to add a "setuid" stanza to this file,
+    # see http://upstart.ubuntu.com/cookbook/#setuid
+end script
+
+post-stop script
+    # cjdns does something wicked with its two processes.
+    # regular upstart pid tracking is not enough to stop the core.
+    kill $(pgrep -f '/usr/bin/cjdroute core')
+end script
+
+exec /usr/bin/cjdroute < /etc/cjdroute.conf


### PR DESCRIPTION
Upstart is the init system used in Ubuntu and some other distros (although others are migrating to systemd).
Compared to sysVinit scripts currently used for autostarting cjdns in Ubuntu, this script makes Upstart do all the heavy lifting instead of using lots and lots of custom bash code of questionable quality.
