### PR TITLE
Init script update

### DIFF
--- a/scripts/cjdns.sh
+++ b/scripts/cjdns.sh
@@ -53,6 +53,10 @@ PID=$(pgrep -d " " -f "$CJDROUTE")
 stop()
 {
     [ ! -z "$PID" ] && kill $PID &> /dev/null
+    while [ -n "$(pgrep -d " " -f "$CJDROUTE")" ]; do
+        echo "* Waiting for CJDNS to shut down..."
+        sleep 1;
+    done
     if [ $? -gt 0 ]; then return 1; fi
 }
 


### PR DESCRIPTION
Previous version did not always restart properly, as `cjdroute` sometimes wouldn't die in time. This makes `stop()` check if cjdns is dead yet and wait if it's not.
