### PR TITLE
Update cjdns.sh

### DIFF
--- a/scripts/cjdns.sh
+++ b/scripts/cjdns.sh
@@ -56,12 +56,17 @@ load_pid
 
 stop()
 {
-    [ ! -z "$PID" ] && kill $PID &> /dev/null
-    while [ -n "$(pgrep -d " " -f "$CJDROUTE")" ]; do
-        echo "* Waiting for CJDNS to shut down..."
-        sleep 1;
-    done
-    if [ $? -gt 0 ]; then return 1; fi
+    if [ -z "$PID" ]; then
+        echo "CJDNS is not running"
+        return 1
+    else
+        kill $PID &> /dev/null
+        while [ -n "$(pgrep -d " " -f "$CJDROUTE")" ]; do
+            echo "* Waiting for CJDNS to shut down..."
+            sleep 1;
+        done
+        if [ $? -gt 0 ]; then return 1; fi
+    fi
 }
 
 start()
@@ -98,6 +103,7 @@ update()
         ./do || echo "Failed to update!" && exit 1
         echo "* Update complete, restarting cjdns"
         stop
+        load_pid
         start
     else
         echo "The cjdns source directory does not exist"


### PR DESCRIPTION
1. If cjdroute is not running, 'cjdns.sh stop' pretends it stops cjdroute, but actually does nothing. Corrected this. Now 'cjdns.sh stop' reports that there's nothing to stop and exist with status 1.
2. As per my comment here (https://github.com/cjdelisle/cjdns/pull/250#issuecomment-21322147), 'cjdns.sh update' falls short of restarting cjdroute, falsely reporting that it's already running. Corrected this. Now it updates, stops cjdroute, rechecks PID and starts the updated cjdroute.
