### PR TITLE
Update cmake version checking

### DIFF
--- a/do
+++ b/do
@@ -40,7 +40,7 @@ if [ -f cmake-build/bin/cmake ]; then
     CMAKE=`pwd`/cmake-build/bin/cmake
 fi
 
-[ ${CMAKE} ] && ${CMAKE} --version | grep '2.8.\([2-9]\|10\)' ||
+[ ${CMAKE} ] && ${CMAKE} --version | grep '2.8.\([2-9]\|[0-9]\{2,\}\)' ||
 while true; do
     [ -d cmake-build ] && rm -r cmake-build
     mkdir cmake-build


### PR DESCRIPTION
When you try to compile it will download a older version of cmake, even if you have a higher version on your system, such as 2.8.11
