### PR TITLE
make sure shell conditionals are properly formed

### DIFF
--- a/do
+++ b/do
@@ -48,8 +48,8 @@ while true; do
 
     APP=`which wget || which curl || echo 'none'`
     [ "$APP" = 'none' ] && echo 'Need wget curl' && exit 1;
-    [ "$APP" = `which wget` ] && $APP ${CMAKE_DOWNLOAD}
-    [ "$APP" = `which curl` ] && $APP ${CMAKE_DOWNLOAD} > cmake.tar.gz
+    [ "x$APP" = x`which wget` ] && $APP ${CMAKE_DOWNLOAD}
+    [ "x$APP" = x`which curl` ] && $APP ${CMAKE_DOWNLOAD} > cmake.tar.gz
 
     ${SHA256SUM} ./*.tar.gz | grep ${CMAKE_SHA256} || exit 1
     tar -xzf *.tar.gz


### PR DESCRIPTION
In the case that wget or curl don't exist, the `[ "$APP" = ... ]` code can turn out to be evaluated like `[ "none" =  ]`, owing to the order in which replacements are done in the shell.

By prefixing everything, the functionality is kept but the error condition is avoided.
