### PR TITLE
Make init function static

### DIFF
--- a/crypto/test/CryptoAuth_test.c
+++ b/crypto/test/CryptoAuth_test.c
@@ -112,7 +112,7 @@ static uint8_t recvMessageOnIf2(struct Message* message, struct Interface* iface
     return Error_NONE;
 }
 
-int init(const uint8_t* privateKey,
+static int init(const uint8_t* privateKey,
          uint8_t* publicKey,
          const uint8_t* password,
          bool authenticatePackets)


### PR DESCRIPTION
This fixes the following failed test on my Ubuntu 12.10 x64 machine:

```
The following tests FAILED:
          6 - CryptoAuth_test (SEGFAULT)
```
