### PR TITLE
SmartOS compile fix

### DIFF
--- a/crypto/random/seed/BsdKernArndSysctlRandomSeed.c
+++ b/crypto/random/seed/BsdKernArndSysctlRandomSeed.c
@@ -21,6 +21,9 @@
     #include <errno.h>
     #include <sys/types.h>
     #include <sys/sysctl.h>
+    #ifndef Illumos
+        #include <sys/sysctl.h>
+    #endif
 #endif
 
 /** Number of times to try each operation. */


### PR DESCRIPTION
avoid include of sys/sysctl.h on Illumos based OS
