### PR TITLE
Update Whitepaper.md

### DIFF
--- a/doc/Whitepaper.md
+++ b/doc/Whitepaper.md
@@ -694,10 +694,10 @@ The journey of a packet begins at the user interface device (TUN or similar).
 The user sends an IPv6 packet which comes in to the TUN device and enters the
 engine, it is checked to make sure its source and destination addresses are
 valid and then a router lookup is made on the destination address. cjdns
-addresses are the first 16 bytes of the SHA-512 of the SHA-512 of the public
-key. All addresses must begin with the byte `0xFC` otherwise they are invalid,
-generating a key is done by brute force key generation until the result of the
-double SHA-512 begins with `0xFC`.
+addresses are the first 16 bytes of the SHA-512 public key. All addresses must
+begin with the byte `0xFC` otherwise they are invalid,generating a key is done
+by brute force key generation until the result of the double SHA-512 begins
+with `0xFC`.
 
 After the router lookup, the node compares the destination address to the
 address of the next router, if they are the same, the inner layer of


### PR DESCRIPTION
Changed "cjdns addresses are the first 16 bytes of the SHA-512 of the SHA-512 of the public key." to
"cjdns addresses are the first 16 bytes of the SHA-512 public key."
