### PR TITLE
remove sys/sysctl.h for SmartOS/Illumos

### DIFF
--- a/crypto/random/seed/BsdKernArndSysctlRandomSeed.c
+++ b/crypto/random/seed/BsdKernArndSysctlRandomSeed.c
@@ -20,7 +20,6 @@
     #include <unistd.h>
     #include <errno.h>
     #include <sys/types.h>
-    #include <sys/sysctl.h>
     #ifndef Illumos
         #include <sys/sysctl.h>
     #endif


### PR DESCRIPTION
this line conflicts with 928466a which was added in 26fc59a5
