### PR TITLE
Changed /usr/bin/python to /usr/bin/env python in the few python scripts...

### DIFF
--- a/contrib/python/cjdnslog
+++ b/contrib/python/cjdnslog
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # You may redistribute this program and/or modify it under the terms of
 # the GNU General Public License as published by the Free Software Foundation,
 # either version 3 of the License, or (at your option) any later version.

--- a/contrib/python/dumptable
+++ b/contrib/python/dumptable
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # You may redistribute this program and/or modify it under the terms of
 # the GNU General Public License as published by the Free Software Foundation,
 # either version 3 of the License, or (at your option) any later version.

--- a/contrib/python/dynamicEndpoints.py
+++ b/contrib/python/dynamicEndpoints.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 # You may redistribute this program and/or modify it under the terms of
 # the GNU General Public License as published by the Free Software Foundation,
 # either version 3 of the License, or (at your option) any later version.


### PR DESCRIPTION
Changed /usr/bin/python to /usr/bin/env python in the few python scripts that weren't already doing so to allow for python binaries in locations other than /usr/bin. In the dynamicEndpoints.py script, I also switched python2 to python, which breaks it on some distros (like Arch Linux) while making it work on others (like Debian;) more importantly however, is that doing this makes things consistant with the other scripts, which are configured to work with how Debian names things.
