### PR TITLE
Implement proper process tracking in Upstart

### DIFF
--- a/contrib/upstart/cjdns.conf
+++ b/contrib/upstart/cjdns.conf
@@ -5,26 +5,37 @@ author "Sergey Davidoff <shnatsel@gmail.com>"
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
-expect daemon
-
 pre-start script
     if ! [ -e /etc/cjdroute.conf ]; then
         touch /etc/cjdroute.conf
         chmod 600 /etc/cjdroute.conf
         /usr/bin/cjdroute --genconf > /etc/cjdroute.conf
-        echo 'WARNING: a new configuration file has been generated.'
+        echo 'WARNING: A new configuration file has been generated.'
+    fi
+
+    if grep -q 'noBackground' /etc/cjdroute.conf; then
+        # Make sure NoBackground is set to something non-zero
+        sed -i 's/"noBackground":0/"noBackground":1 \/\/Must to be non-zero for Upstart to work properly/' /etc/cjdroute.conf
+    else
+        # The config file was generated before noBackground was introduced,
+        # so we'll have to add it! Hang on, this is a little tricky...
+        # trim the last '}' and add the darned ',' to the config file
+        conf="$(cat /etc/cjdroute.conf | tac | sed -e '0,/\}/{s/\}//}' -e '0,/\}/{s/\}/\}\,/}' | tac)"
+        # can't redirect that right away because that clears the file BEFORE it's read
+        echo "$conf" > /etc/cjdroute.conf
+        # add the noBackground part
+        echo '
+    // If set to non-zero, cjdns will not fork to the background.
+    // Recommended for use in conjunction with "logTo":"stdout".
+    "noBackground":1 //Must to be non-zero for Upstart to work properly
+}' >> /etc/cjdroute.conf
+        echo 'WARNING: noBackground stanza was added to your config file.'
     fi
     # If you need a non-standard setup, as described in
     # https://github.com/cjdelisle/cjdns#non-standard-setups,
     # you should add the commands to be run on every boot here.
     # You'll also have to add a "setuid" stanza to this file,
     # see http://upstart.ubuntu.com/cookbook/#setuid
-end script
-
-post-stop script
-    # cjdns does something wicked with its two processes.
-    # regular upstart pid tracking is not enough to stop the core.
-    kill $(pgrep -f '/usr/bin/cjdroute core')
 end script
 
 exec /usr/bin/cjdroute < /etc/cjdroute.conf


### PR DESCRIPTION
Implement proper process tracking in Upstart, and instruct cjdns not to daemonize when starting it from upstart job.

The upstart job now adds noBackground stanza to config file if it's missing, i.e. if the config file was generated before noBackground was introduced, to provide graceful transition for PPA users.
