### PR TITLE
Remove `make` from building instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,6 @@ Clone the repository from GitHub and change to the source directory:
 
 ### 2. Build
 
-    make
-
-Alternatively, you may run the do script directly:
-
     ./do
 
 Look for `Build completed successfully, type ./cjdroute to begin setup.`, then


### PR DESCRIPTION
Ref #343
