### PR TITLE
updated Upstart script to create the config file with 600 permissions without race conditions

### DIFF
--- a/contrib/upstart/cjdns.conf
+++ b/contrib/upstart/cjdns.conf
@@ -7,9 +7,10 @@ stop on runlevel [!2345]
 
 pre-start script
     if ! [ -e /etc/cjdroute.conf ]; then
-        touch /etc/cjdroute.conf
-        chmod 600 /etc/cjdroute.conf
-        /usr/bin/cjdroute --genconf > /etc/cjdroute.conf
+        ( # start a subshell to avoid side effects of umask later on 
+            umask 077 # to create the file with 600 permissions without races
+            /usr/bin/cjdroute --genconf > /etc/cjdroute.conf
+        ) # exit subshell; umask no longer applies
         echo 'WARNING: A new configuration file has been generated.'
     fi
 


### PR DESCRIPTION
Set umask before file creation instead of creating empty file and chmod'ing it to secure the process against race condition attacks (https://github.com/cjdelisle/cjdns/issues/352).
