### PR TITLE
Upstart job: respawn cjdns if it crashes, but no more than once in 180 seconds

### DIFF
--- a/contrib/upstart/cjdns.conf
+++ b/contrib/upstart/cjdns.conf
@@ -5,6 +5,10 @@ author "Sergey Davidoff <shnatsel@gmail.com>"
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
+# respawn cjdns if it crashes, but no more than once in 180 seconds
+respawn
+respawn limit 1 180
+
 pre-start script
     if ! [ -e /etc/cjdroute.conf ]; then
         ( # start a subshell to avoid side effects of umask later on 


### PR DESCRIPTION
I've learned the hard way that cjdns is not entirely stable yet as far as long uptimes go. To prevent important nodes from going out randomly, I'm adding auto-respawning cjdns in case it crashes to Upstart job. 

cjdns will be respawned unless it exits with exit code 0 or is stopped via the Upstart job, but no more than one in 180 seconds to avoid infinite loops on startup with e.g. invalid config file or other error conditions.
