### PR TITLE
Backout broken change to ip6tables.

### DIFF
--- a/contrib/bash/ip6tables.sh
+++ b/contrib/bash/ip6tables.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh -e
+#!/bin/sh -e
 #
 # You may redistribute this program and/or modify it under the terms of
 # the GNU General Public License as published by the Free Software Foundation,


### PR DESCRIPTION
/usr/bin/env sh -e doesn't work.

Fixes issue 370.
