### PR TITLE
Fix reporting of compiler errors in the nacl build with the new build system

### DIFF
--- a/node_build/dependencies/cnacl/node_build/PlanRunner.js
+++ b/node_build/dependencies/cnacl/node_build/PlanRunner.js
@@ -171,7 +171,7 @@ var getCompiler = function(cc) {
     var args = [];
     args.push.apply(args, compileCall.args);
     args.push('-o', compileCall.outFile, '-c', compileCall.inFile);
-    cc(args, function(retCode, stderr) {
+    cc(args, function(retCode, stdout, stderr) {
       if (stderr !== '') { console.log(stderr); }
       if (retCode !== 0) { throw new Error('failed to compile'); }
       onComplete();


### PR DESCRIPTION
The signature of the compiler callback for the nacl build did not match the arguments passed to it from builder.js line 65, causing standard error to be discarded as an extra argument instead of being printed if anything went wrong. This commit fixes that by making the callback take (and ignore) the compiler's standard output, meaning that the standard error parameter gets what it is supposed to get, and errors print correctly.

I have tested this on a failing nacl build, and errors do indeed print correctly.
