### PR TITLE
Ensure wrapper is reset after a peer is shut down and restarted rapidly

### DIFF
--- a/crypto/CryptoAuth.c
+++ b/crypto/CryptoAuth.c
@@ -669,6 +669,10 @@ static uint8_t decryptHandshake(struct CryptoAuth_Wrapper* wrapper,
     // nextNonce 3: recieving first data packet.
     // nextNonce >3: handshake complete
 
+    if (nonce <= 3 && wrapper->established) {
+        reset(wrapper);
+    }
+
     if (knowHerKey(wrapper)) {
         if (Bits_memcmp(wrapper->herPerminentPubKey, header->handshake.publicKey, 32)) {
             cryptoAuthDebug0(wrapper, "DROP a packet with different public key than this session");


### PR DESCRIPTION
It is possible for a new handshake to begin with values still set from the previous connection. In this case you get into a loop of "Incoming hello from node with higher key, not resetting" for one peer and "Sending repeat hello packet" for the other, eventually running out of memory. Resetting the wrapper when we unexpectedly go back to a handshake fixes this.
