### PR TITLE
Initial cross compilion support

### DIFF
--- a/cross-do
+++ b/cross-do
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+cross_log=cross_build_$$.log
+enabled_log=${LOG}
+
+export CROSS=${CROSS_COMPILE}
+export CC=${CROSS}gcc
+export AR=${CROSS}ar
+export RANLIB=${CROSS}ranlib
+export CFLAGS=${CROSS_CFLAGS}
+gcc_version=$(${CC} --version)
+log_filename="${cross_log%.*}"
+echo Using $gcc_version
+rm -rf build_*
+if [ "x$enabled_log" == "x1" ]; then
+  echo Compiler CC: $CC > $cross_log
+  echo Compiler CFLAGS: $CFLAGS >> $cross_log
+  time ./do &>> $cross_log
+  mv cjdroute ${log_filename}_cjdroute
+else
+  echo Compiler CC: $CC
+  echo Compiler CFLAGS: $CFLAGS
+  time ./do
+fi

--- a/node_build/builder.js
+++ b/node_build/builder.js
@@ -64,6 +64,11 @@ var compiler = function (compilerPath, args, callback, content) {
         gcc.on('close', returnAfter(function(ret) {
             callback(ret, out, err);
         }));
+        gcc.on('error', function(err) {
+          // handle the error safely
+          console.log(args);
+          console.log(err);
+        });
         if (content) {
             gcc.stdin.write(content, function (err) {
                 if (err) { throw err; }

--- a/node_build/dependencies/cnacl/node_build/PlanRunner.js
+++ b/node_build/dependencies/cnacl/node_build/PlanRunner.js
@@ -171,7 +171,15 @@ var getCompiler = function(cc) {
     var args = [];
     args.push.apply(args, compileCall.args);
     args.push('-o', compileCall.outFile, '-c', compileCall.inFile);
+    cflags = process.env['CFLAGS'];
+    if (cflags) {
+      flags = cflags.split(' ');
+      flags.forEach(function(flag) {
+        args.push(flag);
+      });
+    }
     cc(args, function(retCode, stdout, stderr) {
+      if (stdout !== '') { console.log(stdout); }
       if (stderr !== '') { console.log(stderr); }
       if (retCode !== 0) { throw new Error('failed to compile'); }
       onComplete();

--- a/node_build/dependencies/cnacl/node_build/RandomBytes.js
+++ b/node_build/dependencies/cnacl/node_build/RandomBytes.js
@@ -7,7 +7,8 @@ module.exports.run = function(cc, onComplete) {
     if (err) { throw err; }
     Fs.writeFile(Common.INCLUDE_INTERNAL + '/randombytes.h', content, function(err) {
       if (err) { throw err; }
-      cc(args, function(retCode, stderr) {
+      cc(args, function(retCode, stdout, stderr) {
+        if (stdout !== '') { console.log(stdout); }
         if (stderr !== '') { console.log(stderr); }
         if (retCode) { throw new Error('failed to compile'); }
         onComplete();

--- a/node_build/dependencies/cnacl/node_build/TestRunner.js
+++ b/node_build/dependencies/cnacl/node_build/TestRunner.js
@@ -16,6 +16,13 @@ var getCompiler = function(cc) {
     args.push.apply(args, compileCall.args);
     args.push('-o', compileCall.outFile, compileCall.inFile);
     args.push(BUILD_DIR + '/libnacl.a');
+    cflags = process.env['CFLAGS'];
+    if (cflags) {
+      flags = cflags.split(' ');
+      flags.forEach(function(flag) {
+        args.push(flag);
+      });
+    }
     cc(args, function(retCode, stdout, stderr) {
       if (stderr !== '') { console.log(stderr); }
       if (retCode !== 0) { throw new Error('failed to compile'); }

--- a/node_build/dependencies/cnacl/node_build/make.js
+++ b/node_build/dependencies/cnacl/node_build/make.js
@@ -8,29 +8,54 @@ var RandomBytes = require('./RandomBytes');
 var Common = require('./Common');
 
 var WORKERS = Os.cpus().length;
+var GCC = process.env['CC'] || 'gcc';
+var AR = process.env['AR'] || 'ar';
+var RANLIB = process.env['RANLIB'] || 'ranlib';
 
 var cc = function(args, onComplete, noArg) {
   if (noArg) { throw new Error(); }
-  var gcc = Spawn('gcc', args);
+  cflags = process.env['CFLAGS'];
+  if (cflags) {
+    flags = cflags.split(' ');
+    flags.forEach(function(flag) {
+      args.push(flag);
+    });
+  }
+  var gcc = Spawn(GCC, args);
   var err = '';
   gcc.stderr.on('data', function(dat) { err += dat.toString() ; });
+  gcc.on('error', function(err) {
+    // handle the error safely
+    console.log(args);
+    console.log(err);
+  });
   gcc.on('close', function(ret) { onComplete(ret, err); });
 };
 
 var ar = function(args, onComplete) {
-  var ar = Spawn('ar', args);
+  var ar = Spawn(AR, args);
   var out = '';
   ar.stderr.on('data', function(dat) { out += dat.toString(); });
   ar.stdout.on('data', function(dat) { out += dat.toString(); });
+  ar.on('error', function(err) {
+    // handle the error safely
+    console.log(args);
+    console.log(err);
+  });
   ar.on('close', function(ret) {
     onComplete(ret, out);
   });
 };
 
 var ranlib = function(args, onComplete) {
-  var rl = Spawn('ranlib', args);
+  var rl = Spawn(RANLIB, args);
   var out = '';
   rl.stderr.on('data', function(dat) { out += dat.toString(); });
+  rl.on('error', function(err) {
+    // handle the error safely
+    console.log(args);
+    console.log(err);
+  });
   rl.on('close', function(ret) {
     onComplete(ret, out);
   });

--- a/node_build/dependencies/cnacl/node_build/plans/armeabi_plan.json
+++ b/node_build/dependencies/cnacl/node_build/plans/armeabi_plan.json
@@ -113,7 +113,9 @@
   ],
   "PLAN_TYPES": [
     "typedef signed char crypto_int8;",
+    "typedef signed int crypto_int32;",
     "typedef short crypto_int16;",
+    "typedef long long crypto_int64;",
     "typedef unsigned char crypto_uint8;",
     "typedef unsigned long long crypto_uint64;",
     "typedef signed long long crypto_int64;",

--- a/node_build/make.js
+++ b/node_build/make.js
@@ -21,6 +21,7 @@ var Os = require('os');
 
 // ['linux','darwin','sunos','win32','freebsd']
 var SYSTEM = process.platform;
+var CROSS = process.env['CROSS'] || '';
 var GCC = process.env['CC'] || 'gcc';
 
 var BUILDDIR = process.env['BUILDDIR'];
@@ -150,6 +151,13 @@ Builder.configure({
             NaCl.build(function (args, callback) {
                 if (builder.config.systemName !== 'win32') { args.unshift('-fPIC'); }
                 args.unshift('-O2', '-fomit-frame-pointer');
+                cflags = process.env['CFLAGS'];
+                if (cflags) {
+                    flags = cflags.split(' ');
+                    flags.forEach(function(flag) {
+                        args.push(flag);
+                    });
+                }
                 builder.cc(args, callback);
             }, waitFor(function () {
                 process.chdir(cwd);
@@ -214,6 +222,7 @@ Builder.configure({
 
     nThen(function (waitFor) {
 
+        if (CROSS) { console.log("Cross compiling.  Test disabled."); return; }
         var out = '';
         var err = '';
         var test = Spawn(BUILDDIR+'/testcjdroute', ['all']);


### PR DESCRIPTION
Finally released the changes I mention on the following issue https://github.com/cjdelisle/cjdns/issues/408 so far I'm able to cross compile successfully, for example to compile for Beaglebone Black using:

```
CROSS_COMPILE=arm-linux-gnueabihf- CROSS_CFLAGS="-O3 -mcpu=cortex-a8 -mfpu=vfp -ftree-vectorize -mfloat-abi=hard -ffast-math -fsingle-precision-constant -g" ./cross-do
```

However a binary generated with NEON does not work, see issue #408 for the problem:

```
CROSS_COMPILE=arm-linux-gnueabihf- CROSS_CFLAGS="-O3 -mcpu=cortex-a8 -mfpu=neon -ftree-vectorize -mfloat-abi=hard -ffast-math -fsingle-precision-constant -g" ./cross-do
```

The toolchain I use for crosspilation from debian or ubuntu I used [linaro](https://launchpad.net/linaro-toolchain-binaries/trunk/2013.10) 
