### PR TITLE
Add "config" entry to .cjdnsadmin file upon creation

### DIFF
--- a/contrib/python/cjdnsadminmaker.py
+++ b/contrib/python/cjdnsadminmaker.py
@@ -96,6 +96,7 @@ while not done:
         cjdnsadmin["addr"] = addr
         cjdnsadmin["port"] = int(port)
         cjdnsadmin["password"] = cjdrouteconf['admin']['password']
+        cjdnsadmin["config"] = conf
         adminfile = open(os.getenv("HOME") + "/.cjdnsadmin", "w+")
         adminfile.write(json.dumps(cjdnsadmin, indent=4))
         adminfile.close()


### PR DESCRIPTION
This allows interface developers to query .cjdnsadmin for the location of
cjdroute.conf rather than reimplementing the check each time.  Cjdcmd already
does it, this just makes it more standard.
