### PR TITLE
Set maximum size of created files while downloading node.js to 10Mb, ...

### DIFF
--- a/do
+++ b/do
@@ -75,8 +75,10 @@ getNode()
 
     APP=`which wget || which curl || echo 'none'`
     [ "$APP" = 'none' ] && echo 'wget or curl is required download node.js but you have neither!' && return 1
+    ( ulimit -f 20000 # prohibit creation of files more than 10Mb in size
     [ "x$APP" = x`which wget` ] && $APP ${NODE_DOWNLOAD}
     [ "x$APP" = x`which curl` ] && $APP ${NODE_DOWNLOAD} > node.tar.gz
+    )
 
     if ! ( ${SHA256SUM} ./*.tar.gz | grep -q ${NODE_SHA} ); then
         echo 'The downloaded file is damaged! Aborting.'


### PR DESCRIPTION
...to prevent an attacker from susbstituting an endless stream and exhausting available disk space on the machine.

The use of ulimit in here is POSIX-compliant and should not break even such weird systems as SunOS.

The largest current tarball of node.js is 6.4Mb in size so 10Mb limit is rather generous and should be future-proof.
