### PR TITLE
Make the wget/curl lookup more robust and portable

### DIFF
--- a/do
+++ b/do
@@ -76,10 +76,14 @@ getNode()
     mkdir -p "${BUILDDIR}/nodejs"
     cd "${BUILDDIR}/nodejs"
 
-    APP="$(which wget || which curl || echo 'none')"
-    [ "$APP" = 'none' ] && echo 'wget or curl is required download node.js but you have neither!' && return 1
-    [ "x$APP" = x"$(which wget)" ] && $APP -O - ${NODE_DOWNLOAD} > node.tar.gz
-    [ "x$APP" = x"$(which curl)" ] && $APP ${NODE_DOWNLOAD} > node.tar.gz
+    if wget --version > /dev/null 2>&1; then
+        wget -O - "${NODE_DOWNLOAD}" > node.tar.gz
+    elif curl --version > /dev/null 2>&1; then
+        curl "${NODE_DOWNLOAD}" > node.tar.gz
+    else
+        echo 'wget or curl is required download node.js but you have neither!'
+        return 1
+    fi
 
     if ! ( ${SHA256SUM} node.tar.gz | grep -q ${NODE_SHA} ); then
         echo 'The downloaded file is damaged! Aborting.'


### PR DESCRIPTION
Get rid of unreliable globbing for the downloaded node.js distribution by using deterministic output file name.

Do not rely on "which" reporting an error because that's not portable - on some plaftorms it doesn't report an error if it finds nothing. Replace it with more portable and readable code.
