### PR TITLE
Set number of cpus to 1 if `os.cpus().length` is undefined.

### DIFF
--- a/node_build/builder.js
+++ b/node_build/builder.js
@@ -40,8 +40,10 @@ var Semaphore = require('./Semaphore');
  * The Creator
  */
 
-// Since many of the compile operations are short, the best performance seems
-// to be when running 1.25x the number of jobs as cpu cores.
+// Since many of the compile operations are short, the best
+// performance seems to be when running 1.25x the number of jobs as
+// cpu cores. On BSD and iphone systems, os.cpus() is not reliable so
+// if it returns undefined let's just assume 1
 var WORKERS = Math.floor((typeof Os.cpus() == 'undefined' ? 1 : Os.cpus().length) * 1.25);
 
 var error = function (message)

--- a/node_build/dependencies/cnacl/node_build/make.js
+++ b/node_build/dependencies/cnacl/node_build/make.js
@@ -7,6 +7,8 @@ var TestRunner = require('./TestRunner');
 var RandomBytes = require('./RandomBytes');
 var Common = require('./Common');
 
+// on BSD and iphone systems, os.cpus() is not reliable so if it
+// returns undefined let's just assume 1
 var WORKERS = Math.floor((typeof Os.cpus() == 'undefined' ? 1 : Os.cpus().length));
 
 var GCC = process.env['CC'] || 'gcc';

--- a/node_build/make.js
+++ b/node_build/make.js
@@ -27,7 +27,10 @@ var GCC = process.env['CC'] || 'gcc';
 var BUILDDIR = process.env['BUILDDIR'];
 if (BUILDDIR === undefined) {
     BUILDDIR = 'build_'+SYSTEM;
+
 }
+// on BSD and iphone systems, os.cpus() is not reliable so if it
+// returns undefined, let's just assume 1
 var WORKERS = Math.floor((typeof Os.cpus() == 'undefined' ? 1 : Os.cpus().length) * 1.25);
 
 process.on('exit', function () {


### PR DESCRIPTION
I was working on trying to build cjdns on my iPhone and I came across a problem. `Os.cpus().length` always returned `undefined` for me. I'm not sure the percentage of systems that do have this problem, but I'm sure there are some if I've found one. 

Anyways, if node can't figure out how many cpus a user has it should really just default to 1 so there are no problems. 
