### PR TITLE
add ldflags to cross-do script

### DIFF
--- a/cross-do
+++ b/cross-do
@@ -8,6 +8,7 @@ export CC=${CROSS}gcc
 export AR=${CROSS}ar
 export RANLIB=${CROSS}ranlib
 export CFLAGS=${CROSS_CFLAGS}
+export LDFLAGS=${CROSS_LDFLAGS}
 gcc_version=$(${CC} --version)
 log_filename="${cross_log%.*}"
 echo Using $gcc_version
@@ -15,10 +16,12 @@ rm -rf build_*
 if [ "x$enabled_log" == "x1" ]; then
   echo Compiler CC: $CC > $cross_log
   echo Compiler CFLAGS: $CFLAGS >> $cross_log
+  echo Compiler LDFLAGS: $LDFLAGS >> $cross_log
   time ./do &>> $cross_log
   mv cjdroute ${log_filename}_cjdroute
 else
   echo Compiler CC: $CC
   echo Compiler CFLAGS: $CFLAGS
+  echo Compiler LDFLAGS: $LDFLAGS
   time ./do
 fi


### PR DESCRIPTION
This is the reason why I was not able to cross compile for Beaglebone Black (BBB), not sure how I missed the LDFLAGS.

Build log: https://gist.github.com/nandub/9202387
EDIT: Cross compiling from ubuntu saucy to BBB using arm-linux-gnueabihf-gcc (crosstool-NG linaro-1.13.1-4.8-2013.10 - Linaro GCC 2013.10) 4.8.2 20131014 (prerelease)

Command used:

```
CROSS_COMPILE=arm-linux-gnueabihf- CROSS_CFLAGS="-march=armv7-a -mtune=cortex-a8 -marm -mfloat-abi=hard -mfpu=neon -g" CROSS_LDFLAGS="-march=armv7-a -mtune=cortex-a8 -marm -mfloat-abi=hard -mfpu=neon -g" ./cross-do
```
