### PR TITLE
fixed ./do

### DIFF
--- a/do
+++ b/do
@@ -16,9 +16,9 @@
 BUILDDIR="build_${PLATFORM}"
 NODE_MIN_VER="v0.8.15"
 
-for PYTHON2 in "`which python`" "`which python2`" "`which python2.7`" "false"; do
+for PYTHON2 in "`which python 2>/dev/null`" "`which python2 2>/dev/null`" "`which python2.7 2>/dev/null`" "false"; do
     ${PYTHON2} --version 2>&1 | grep '2.7' >/dev/null 2>/dev/null && break;
-    [ "x${PYTHON2}" = "xfalse" ] && echo 'No sutible python2.7 version found' && exit 1;
+    [ "x${PYTHON2}" = "xfalse" ] && echo 'No suitable python2.7 version found' && exit 1;
 done
 
 hasOkNode()
@@ -112,7 +112,7 @@ main() {
     getsha256sum || die "couldn't find working sha256 hasher";
     hasOkNode || getNode || die "could not get working nodejs impl";
 
-    $NODE ./node_build/make.js "${@}" || return 1
+    PYTHON2=$PYTHON2 $NODE ./node_build/make.js "${@}" || return 1
 }
 
 main


### PR DESCRIPTION
Minor spelling error and silenced errors from which when python does not exist
Sets PYTHON2 when calling node explictly, which is needed for some reason?
