### PR TITLE
If python doesn't exist in PATH, or python --version isn't 2.7.x, check ...

### DIFF
--- a/do
+++ b/do
@@ -11,15 +11,26 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+pythonfix()
+{
+    for PYTHON2 in "python2" "python2.7" "false"; do
+        [[ -e pathfix/python ]] && break
+        if [ ! $PYTHON2 = "false" ]; then
+            type -P $PYTHON2 >/dev/null 2>&1 \
+                && [[ -n $(`type -P python2` --version 2>&1 | grep -o "2.7") ]] && install -d pathfix && ln -s `type -P $PYTHON2` pathfix/python \
+                || (echo "Error: Cannot create the files necessary to override the system's python version with python 2.7 for the build process." && exit 1)
+        else
+            echo "Error: No suitable version of python 2.7 found, please install and try again." && exit 1
+        fi
+    done
+}
+type python >/dev/null 2>&1 && (python --version 2>&1 | grep 2.7 || pythonfix) || pythonfix
+[[ -d pathfix ]] && export PATH="${PWD}/pathfix":$PATH
+
 [ -n "$PLATFORM" ] || PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
 [ -n "$MARCH" ] || MARCH=$(uname -m | sed "s/i./x/g")
 BUILDDIR="build_${PLATFORM}"
 NODE_MIN_VER="v0.8.15"
-
-for PYTHON2 in "`which python`" "`which python2`" "`which python2.7`" "false"; do
-    ${PYTHON2} --version 2>&1 | grep '2.7' >/dev/null 2>/dev/null && break;
-    [ "x${PYTHON2}" = "xfalse" ] && echo 'No sutible python2.7 version found' && exit 1;
-done
 
 hasOkNode()
 {


### PR DESCRIPTION
from the commit: If python doesn't exist in PATH, or python --version isn't 2.7.x, check to see if python2 or python2.7 exist, and if they have a python version of 2.7.x, add a symlink to it named python in a local directory and override PATH with that directory.

I tested it on Arch after a fresh clone and again with the symlink already made.
