### PR TITLE
Orphaned direct peer bug

### DIFF
--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -858,7 +858,7 @@ static struct Node_Link* discoverLink(struct NodeStore_pvt* store,
     if (pathParentChild == findClosest_INVALID) {
         return NULL;
     }
-    if (closest->child == child) {
+    if (closest->child == child && closestKnown != store->selfLink) {
         return NULL;
     }
 


### PR DESCRIPTION
This bug is back. If I lose my connection to my direct peers (e.g. wifi disconnect because I walked between buildings, suspending my computer, etc.) then all peers are disconnected as expected. However, after the connection comes back online, direct peers never recover, which prevents all connectivity.

The below 1-line fix is sufficient to get direct peers working again. I don't know if this is the "right" way to fix it (maybe it leaks loop-links into the store?), but I think it's the right condition to check for at least.
