### PR TITLE
[nacl/plans] mips32 including crypto_onetimeauth, poly1305, donna32

### DIFF
--- a/node_build/dependencies/cnacl/node_build/plans/mipso32_plan.json
+++ b/node_build/dependencies/cnacl/node_build/plans/mipso32_plan.json
@@ -1,0 +1,119 @@
+{
+  "PLAN_IMPLEMENTATIONS": [
+    [
+      "crypto_hashblocks",
+      "sha512",
+      "inplace"
+    ],
+    [
+      "crypto_core",
+      "salsa208",
+      "ref"
+    ],
+    [
+      "crypto_stream",
+      "xsalsa20",
+      "ref"
+    ],
+    [
+      "crypto_hash",
+      "sha512",
+      "ref"
+    ],
+    [
+      "crypto_verify",
+      "16",
+      "ref"
+    ],
+    [
+      "crypto_core",
+      "hsalsa20",
+      "ref2"
+    ],
+    [
+      "crypto_stream",
+      "salsa20",
+      "ref"
+    ],
+    [
+      "crypto_sign",
+      "ed25519",
+      "ref"
+    ],
+    [
+      "crypto_auth",
+      "hmacsha512256",
+      "ref"
+    ],
+    [
+      "crypto_scalarmult",
+      "curve25519",
+      "ref10"
+    ],
+    [
+      "crypto_box",
+      "curve25519xsalsa20poly1305",
+      "ref"
+    ],
+    [
+      "crypto_stream",
+      "salsa208",
+      "ref"
+    ],
+    [
+      "crypto_onetimeauth",
+      "poly1305",
+      "donna32"
+    ],
+    [
+      "crypto_hash",
+      "sha256",
+      "ref"
+    ],
+    [
+      "crypto_hashblocks",
+      "sha256",
+      "ref"
+    ],
+    [
+      "crypto_core",
+      "salsa20",
+      "ref"
+    ],
+    [
+      "crypto_secretbox",
+      "xsalsa20poly1305",
+      "ref"
+    ],
+    [
+      "crypto_auth",
+      "hmacsha256",
+      "ref"
+    ],
+    [
+      "crypto_core",
+      "salsa2012",
+      "ref"
+    ],
+    [
+      "crypto_stream",
+      "salsa2012",
+      "ref"
+    ],
+    [
+      "crypto_verify",
+      "32",
+      "ref"
+    ]
+  ],
+  "PLAN_TYPES": [
+    "typedef unsigned char crypto_uint8;",
+    "typedef unsigned short crypto_uint16;",
+    "typedef int crypto_int32;",
+    "typedef signed char crypto_int8;",
+    "typedef unsigned int crypto_uint32;",
+    "typedef unsigned long long crypto_uint64;",
+    "typedef long long crypto_int64;",
+    "typedef short crypto_int16;"
+  ]
+}


### PR DESCRIPTION
compare this plan (with donna32) vs. [cjdelisle/cjdns-openwrt] 67f196c74f38fcf2d62c11906720dd40ba0919cd
this plan does not include crypto_stream, aes128ctr, portable
