### PR TITLE
Allow time() syscall in seccomp

### DIFF
--- a/util/Seccomp.c
+++ b/util/Seccomp.c
@@ -116,6 +116,11 @@ void Seccomp_dropPermissions(struct Except* eh)
     #endif
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(mmap2), 0);
 
+    // Seem to be used on i686 (Linux 3.12.18 SMP PREEMPT i686 GNU/Linux) from glibc-2.18's time()
+    #ifdef __NR_time
+        rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(time), 0);
+    #endif
+
     // printf
     rc |= seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(fstat), 0);
 


### PR DESCRIPTION
Linux 3.12.18 SMP PREEMPT i686 GNU/Linux and glibc-2.18 produces following backtrace upon trying to connect to cjdns with `./contrib/python/cjdnslog ''`: http://bpaste.net/raw/253298/
Register values: http://bpaste.net/raw/253310/
`echo '#include <seccomp.h>' | cpp -dM - | grep ' 13'`: http://bpaste.net/raw/253320/

Added conditional rule for the thing, as suggested in #cjdns
