### PR TITLE
Fix AppArmor profile to work on Ubuntu 14.04

### DIFF
--- a/contrib/apparmor/usr.bin.cjdroute
+++ b/contrib/apparmor/usr.bin.cjdroute
@@ -20,7 +20,7 @@
   /dev/net/tun rw,
   /etc/passwd mr,
   /proc/sys/kernel/random/uuid r,
-  /tmp/cjdns_pipe_* w,
+  /tmp/cjdns_pipe_* rw,
   /usr/bin/cjdroute mrix,
 
 # if you choose to use a pidfile, you'll have to speficy it here as well


### PR DESCRIPTION
Newer versions of AppArmor handle w's on files slightly different. This change is needed to make cjdns confined by the profile work on Ubuntu 14.04

This bug was found & fixed by Damon Gant
