### PR TITLE
Make "FindPython2.js" look for "python2" first

### DIFF
--- a/node_build/FindPython2.js
+++ b/node_build/FindPython2.js
@@ -16,7 +16,7 @@ var nThen = require('nthen');
 var Spawn = require('child_process').spawn;
 var Fs = require('fs');
 
-var PYTHONS = ["python", "python2", "python2.7", "python2.6", "python2.5"];
+var PYTHONS = ["python2", "python", "python2.7", "python2.6", "python2.5"];
 
 var find = module.exports.find = function (tempFile, callback) {
     var nt = nThen(function (waitFor) {


### PR DESCRIPTION
Fixes build breakage on Arch (+Derivatives): https://github.com/cjdelisle/cjdns/issues/530

As more and more distros switch to Python3.x by default, this would be a necessary change anyway.
