### PR TITLE
Set MTU for device and mention boot script

### DIFF
--- a/doc/non-root-user.md
+++ b/doc/non-root-user.md
@@ -17,7 +17,7 @@ Create a new TUN device and give the cjdns user authority to access it:
 Run those commands to prepare your TUN device:
 
     sudo /sbin/ip addr add <your ipv6 address>/8 dev cjdroute0
-    sudo /sbin/ip link set mtu 1400 dev cjdroute0
+    sudo /sbin/ip link set mtu 1312 dev cjdroute0
     sudo /sbin/ip link set cjdroute0 up
 
 These commands should be executed as root now every time the system restarts.


### PR DESCRIPTION
The code tries setting the interface 'up' and 'running'. Setting the MTU may be required to get it running.

Adding the commands to a boot script may also help push people in the right direction.
