### PR TITLE
Android: More fixes + improvements to README, and support for $ANDROID_NDK

### DIFF
--- a/contrib/android/README.md
+++ b/contrib/android/README.md
@@ -11,7 +11,7 @@
 
 ### Build Instructions ##
 
-1. **Configure Location of Android NDK** (optional): If you already have the Android NDK installed, set the _$NDK_ variable in your shell to the path of the folder where it's located. (eg: `export NDK="/opt/android-ndk"`)
+1. **Configure Location of Android NDK** (optional): If you have a version of the Android NDK installed, and it isn't pointed to by the (standard) variable: _$ANDROID_NDK_, set the _$NDK_ variable in your shell to point to the directory it's located. (eg: `export NDK="/opt/android-ndk"`)
 2. **Configure Alternative Repository** (optional): To use an alternative repository, open _cjdroid-build.sh_ and edit _REPO=https://github.com/cjdelisle/cjdns.git_ to point to the URL of your desired repository. (eg: _REPO="http://newrepo"_)
   * **NOTE**: You must remove the _cjdns-android/cjdns_ folder if it exists after changing the repo before you can run _cjdroid-build.sh_ again.
 3. **Configure Alternative Branch** (optional): To use a branch other than _master_, open _cjdroid-build.sh_ and edit _BRANCH="master"_ to use the name of your desired branch. (eg: _BRANCH="newbranch"_)
@@ -21,46 +21,55 @@
 
 ### Requirements ###
 
-* **Root**: This is required to install things to the _/system_ partition as well as configure the network. The method required to root a phone differs from model to model.  If your phone isn't rooted yet and you're not sure where to start, look for the subforum for your device on XDA forums (linked below), and hopefully you'll find something that works.
-* **Tun Support**: This provides the interface cjdns uses to create a virtual network device. Most (if not all) 4.0+ phones include tun support. If yours uses 2.x, CyanogenMod and some stock ROMs include support, but many don't. If your phone doesn't have a TUN device at /dev/tun, download [com.aed.tun.installer](http://cjdns.ca/com.aed.tun.installer.apk), then install and run it to have it set one up for you.
+* **Root**: Root privileges are required to install things in the _/system_ partition, and to configure the network using tun. The method required to root a phone differs from model to model.  If your phone isn't rooted yet and you're not sure where to start, look for the subforum for your device on [XDA forums](http://forum.xda-developers.com), and hopefully you'll find something that works.
+* **Tun**: This provides the interface cjdns uses to create a virtual network device. Most (if not all) 4.0+ phones include tun support. If yours uses 2.x, CyanogenMod and some stock ROMs include support, but many don't. If your phone doesn't have a TUN device at /dev/tun, download [com.aed.tun.installer](http://cjdns.ca/com.aed.tun.installer.apk), then install and run it to have it set one up for you.
 
 ### Setup Instructions ###
 
-After building _cjdroute_, the _cjdroid-build.sh_ script will generate a compressed file named something like _cjdroid-version.tar.gz_ (eg: _cjdroid-0.3.2380.tar.gz_.)
+After building _cjdroute_, the _cjdroid-build.sh_ script will generate a compressed file named _cjdroid-${version}.tar.gz_, except with the commit version in place of ${version} (eg: _cjdroid-0.3.2380.tar.gz_)
 
-1. Copy the compressed file to your Android device and extract it.
-2. Become root by running: `su`
-3. Execute the install script by running: `sh cjdroid/install.sh`
-3. Create a directory in _/sdcard_ named _cjdns_ by running: `mkdir /sdcard/cjdns`
-4. Either copy a premade cjdroute.conf file to _/sdcard/cjdns/cjdroute.conf_, or create a new one by running: `cjdroute --genconf > /sdcard/cjdns/cjdroute.conf`
-5. Add peers to the connectTo section of _/sdcard/cjdns/cjdroute.conf_ if necessary.
-6. Run `cjdctl start` to start _cjdaemon_ and _cjdroute_.
-7. Test to make sure everything is working:
-  * **Check Configuration**: Check that your tun device (usually tun0) was configured correctly by running: `ip addr`
-  * **Check Process**: Ensure cjdroute is running with the following command: `ps | grep cjdroute`
-  * **Check Config**: Starting _cjdroute_ manually by running `cjdroute < /sdcard/cjdns/cjdroute.conf` should output to stdout, which you can use to help debug configuration issues.
-  * **Ping Test**: Find the ipv6 of one of your peers and run `ping6 ipv6address`
-  * **Admin Port**: You can configure the _admin_ section in your cjdroute.conf to bind to the ipv4 of your local network, then connect using the tools included in the _contrib_ folder to help debug issues.
-  * **NOTE**: Remember that _/sdcard/cjdns/cjdroute.conf_ must exist for _cjdctl_ or _cjdaemon_ to start _cjdroute_.
+1. Copy the compressed file to your Android device using a method you're comfortable with, such as running: `adb push cjdroid-${version}.tar.gz /sdcard/`
+2. Get a shell running on your Android device:
+  * From your PC using adb: `adb shell`
+  * On your Android device using _Terminal Emulator_.
+3. Extract the compressed file: `tar zxvf /sdcard/cjdroid-${version}.tar.gz`
+4. Become root by running: `su`
+5. Execute the install script by running: `sh /sdcard/cjdroid/install.sh`
+  * **NOTE**: Wiping the _/system_ partition for any reason, including to update your ROM, will remove the installed files and disable cjdns until this command is run again.
+6. Create a directory in _/sdcard_ named _cjdns_ by running: `mkdir /sdcard/cjdns`
+7. Either copy a premade cjdroute.conf file to _/sdcard/cjdns/cjdroute.conf_, or create a new one by running: `cjdroute --genconf > /sdcard/cjdns/cjdroute.conf`
+8. Add peers to the connectTo section of _/sdcard/cjdns/cjdroute.conf_ if necessary.
+9. Run `cjdctl start` to start _cjdaemon_ and _cjdroute_.
 
 ### Commands ###
 
-Once _install.sh_ is run and _/sdcard/cjdns/cjdroute.conf_ exists, _cjdctl_ can be run as root from the commandline with the following options:
+Once _install.sh_ is run and _/sdcard/cjdns/cjdroute.conf_ exists, _cjdctl_ can be run as root from the command line with the following options:
 
-* **cjdctl start**: Run cjdroute and the daemon, and tell the daemon to start cjdroute at runtime and when the phone wakes (this state will continue after restarting.)
-* **cjdctl stop**: Stop cjdroute and tell the daemon not to start cjdroute at runtime or when the phone wakes (this state will continue after restarting.)
-* **cjdctl restart**: Run the stop and start commands above, in that order.
-* **cjdctl start-daemon**: Start the daemon if it isn_t running, which will then start cjdroute on init and when the phone wakes based on the state set by the most recent start/stop command, and stop cjdroute when the phone sleeps.
-* **cjdctl stop-daemon**: Stop the daemon if it's running, preventing cjdroute from being stopped when the phone sleeps and started when it wakes.
-* **NOTE**: Once cjdns starts successfully after running `cjdctl start`, it will automatically start on boot and stop/start on sleep/wake until the `cjdctl stop` is run.
+* cjdctl **start**: Run cjdroute and the daemon + set the daemon to start _cjdroute_ on boot and wakeup.
+* cjdctl **stop**: Stop cjdroute + set the daemon to do nothing on boot and wakeup.
+* cjdctl **restart**: Run the stop command above followed by the start command above.
+* cjdctl **start-daemon**: Start the daemon if it isn't running (does not start _cjdroute_ unless the daemon has been set to do so.)
+* cjdctl **stop-daemon**: Stop the daemon if it's running (does not stop _cjdroute_.)
+* **NOTE**: Remember that once `cjdctl start` has been run, cjdroute will start on boot and wakeup until running the `cjdctl stop` command.
+
+### Issues ###
+
+If you followed the instructions and things don't appear to be working, try some of these ideas to see if you can figure out what's wrong:
+
+* **Test Debugging Output**: Starting _cjdroute_ manually by running `cjdroute < /sdcard/cjdns/cjdroute.conf` should output to stdout, which you can use to help debug configuration issues.
+* **Test Ping**: Find the ipv6 of one of your peers and run `ping6 ipv6address`
+* **Test Admin Port**: Configure the _admin_ section on your Android device's _cjdroute.conf_ to bind to the ipv4 of your local network, then connect remotely from a PC and using tools from _contrib_.
+* **Does Config Exist?**: A valid _cjdroute.conf_ must exist @ _/sdcard/cjdns/cjdroute.conf_ for _cjdctl_ or _cjdaemon_ to start _cjdroute_.
+* **Are Process Running?**: Ensure cjdroute is running with the following command: `ps | grep cjdroute`
+* **Is Network Configured?**: Check that your tun device (usually tun0) was configured correctly (exists and has an ipv6 starting with fc*) by running: `ip addr`
 
 ### Files ###
 
-Below is a list of the files contained in _cjdroid-version.tar.gz_:
+Below is a list of the files contained in _cjdroid-${version}.tar.gz_:
 
-* **install.sh** (run by user as root): This remounts _/system_ read/write and installs everything in the _files_ folder in their respective locations.
-* **files/99cjdroute** (run by system): Deployed to _/system/etc/init.d/99cjdroute_, this is run at boot to start _cjdaemon_.
-* **files/cjdaemon** (run by system): Deployed to _/system/bin/cjdaemon_, this starts cjdroute if it's supposed to be running, then stops it when the phone sleeps and starts it again if it's supposed to be running when the phone wakes back up.
-* **files/cjdctl** (run by user as root): Deployed to _/system/bin/cjdctl_, this lets you control cjdroute as well as the daemon.
-* **files/cjdroute** (run by user as root and system): This is the _cjdroute_ binary, which can be used like normal to generate a config file with: `cjdroute --genconf > /sdcard/cjdns/cjdroute.conf`, and you can run: `cjdroute < /sdcard/cjdns/cjdroute.conf` to start it manually (running it manually may result in higher than normal battery drain in sleep mode).
-* **NOTE**: The files included in _cjdroid-version.tar.gz_ are from the repo cloned by _cjdroid-build.sh_ @  _cjdns-android/cjdns_ (and not the current repository, if you're running a copy of _cjdroid-build.sh_ from inside one.)
+* **install.sh** (run by _user_ as _root_): This remounts _/system_ read/write, installs the files described below to their respective locations, then remounts _/system_ read-only.
+* **files/99cjdroute** (run by _system_): Deployed to _/system/etc/init.d/99cjdroute_, this is run at boot to start _cjdaemon_.
+* **files/cjdaemon** (run by _system_ and _cjdctl_): Deployed to _/system/bin/cjdaemon_, this starts cjdroute if it's supposed to be running, then stops it when the phone sleeps and starts it again if it's supposed to be running when the phone wakes back up.
+* **files/cjdctl** (run by _user_ as _root_): Deployed to _/system/bin/cjdctl_, this lets you control cjdroute as well as the daemon.
+* **files/cjdroute** (run by _user_ as _root_ and _system_): This is the _cjdroute_ binary, which can be used like normal to generate a config file with: `cjdroute --genconf > /sdcard/cjdns/cjdroute.conf`, and you can run: `cjdroute < /sdcard/cjdns/cjdroute.conf` to start it manually (running it manually may result in higher than normal battery drain in sleep mode).
+* **NOTE**: The files included in _cjdroid-${version}.tar.gz_ are from the repo cloned by _cjdroid-build.sh_ @  _cjdns-android/cjdns_ (and not the current repository, if you're running a copy of _cjdroid-build.sh_ from inside one.)

--- a/contrib/android/cjdroid-build.sh
+++ b/contrib/android/cjdroid-build.sh
@@ -69,13 +69,16 @@ install -d "$WORK_DIR"
 ## SETUP NDK
 cd "$SRC_DIR"
 if [ -z "$NDK" ]; then
-    echo "${NDKVER}-linux-${ARCH}.tar.bz2"
-    [[ -f "${NDKVER}-linux-${ARCH}.tar.bz2" ]] || wget "http://dl.google.com/android/ndk/${NDKVER}-linux-${ARCH}.tar.bz2" || (echo "Can't find download for your system" && exit 1)
-    [[ -d "${NDKVER}" ]] || (tar jxf "${NDKVER}-linux-${ARCH}.tar.bz2" || exit 1)
-    NDK="$NDKVER"
-else
-    [[ -d "$NDK" ]] || (echo "The NDK variable is not pointing to a valid directory" ; exit 1)
+    if [ -z "$ANDROID_NDK" ]; then
+        echo "${NDKVER}-linux-${ARCH}.tar.bz2"
+        [[ -f "${NDKVER}-linux-${ARCH}.tar.bz2" ]] || wget "http://dl.google.com/android/ndk/${NDKVER}-linux-${ARCH}.tar.bz2" || (echo "Can't find download for your system" && exit 1)
+        [[ -d "${NDKVER}" ]] || (tar jxf "${NDKVER}-linux-${ARCH}.tar.bz2" || exit 1)
+        NDK="$NDKVER"
+    else
+        NDK="$ANDROID_NDK"
+    fi
 fi
+[[ -d "$NDK" ]] || (echo "The NDK variable is not pointing to a valid directory" ; exit 1)
 [[ -e "$NDK_DIR" ]] && rm "$NDK_DIR" >> /dev/null 2>&1
 ln -s "$NDK" "$NDK_DIR"
 


### PR DESCRIPTION
cjdroid-build.sh: The $ANDROID_NDK variable is now used to locate the Android NDK if the user hasn't configured a custom location using $NDK. The Android NDK packages provided by some distros set $ANDROID_NDK to its installation directory, meaning users of these packages won't require any intervention to get the script to use their system's install.

README.md: More detail was added to some areas that needed it, the debugging step was pulled out and into its own section, some typos were fixed, sections better organized, formatting improved and some info changed to reflect the updated build script (above).
