### PR TITLE
Slightly more correct buckets

### DIFF
--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -1212,7 +1212,7 @@ static bool markBestNodes(struct NodeStore_pvt* store,
                     break;
                 }
                 if ( (newNode->marked && !nodeList->nodes[i]->marked) ||
-                     (Node_getReach(nodeList->nodes[i]) < Node_getReach(newNode)) ) {
+                      whichIsWorse(nodeList->nodes[i], newNode, store) == nodeList->nodes[i] ) {
                     // If we've already marked nodes because they're a bestParent,
                     // lets give them priority in the bucket since we need to keep
                     // them either way.


### PR DESCRIPTION
1 line change.

Instead of directly comparing reach for two nodes when deciding which to protect, use whichIsWorse. It's basically the same thing, modulo nodes with different versions, but it's more consistent to do it this way considering the other checks being done when finding the worst node in the NodeStore.
