### PR TITLE
improvements for nodejs module of `admin`

### DIFF
--- a/contrib/nodejs/admin/admin.js
+++ b/contrib/nodejs/admin/admin.js
@@ -211,4 +211,6 @@ cjdns.subscribe(function (err, resp) {
     }
 });
 
-app.listen(8084);
+app.listen(8084,'127.0.0.1',function(){
+  console.log('\n****************\nCJDNS admin is started on http://localhost:8084/ \n****************\n ');
+});

--- a/contrib/nodejs/admin/package.json
+++ b/contrib/nodejs/admin/package.json
@@ -2,8 +2,19 @@
   "name": "cjdns-admin",
   "description": "Admin panel for cjdns",
   "version": "0.0.2",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:cjdelisle/cjdns.git"
+  },
+  "engines": {
+    "node": ">=0.10.26",
+    "npm": ">=1.4.3"
+  },
   "dependencies": {
     "express": "3.x",
     "bencode": "x"
+  },
+  "scripts": {
+    "start": "node admin.js"
   }
 }


### PR DESCRIPTION
1) it listens on 127.0.0.1 host - accepts only connections from localhost!
2) it can be started by `npm start`
3) it has correct nodejs and npm version requirements
4) it is more user friendly - it console.log's a message with URL to open to access it.
