### PR TITLE
Fix skip make.js steps if exists more one valid python version

### DIFF
--- a/node_build/FindPython2.js
+++ b/node_build/FindPython2.js
@@ -39,7 +39,6 @@ var find = module.exports.find = function (tempFile, callback) {
             });
             py.on('error', function (err) {
                 if (err !== 'ENOENT') { console.log('error starting python ' + err); }
-                cont();
             });
             // Don't worry about errors, try the next.
         }).nThen;


### PR DESCRIPTION
Spawn trigger 'close' event after 'error', even if the program does not exist.
