### PR TITLE
Android: Improved branch support and error handling in the Android build script

### DIFF
--- a/contrib/android/README.md
+++ b/contrib/android/README.md
@@ -18,7 +18,8 @@
 
 ### Build and Package ###
 
-Run _cjdroid-build.sh_ and wait until it completes.
+ * To clone a fresh repo and build, run `./cjdroid-build.sh` or `./cjdroid-build.sh branchname`.
+ * To use the current repo and branch, you can run `./do android` from the cjdns directory.
 
 ## Deploy CJDNS for Android ##
 


### PR DESCRIPTION
You can now specify a branch as an argument when building for Android, rather than needing to edit the build script to do this, and branch handling in general is done much better. Also, the branch name is now included in the generated package's name when it's specified now too. I also added some error handling in a few spots where continuing wouldn't make sense if the step failed.

These changes are the same as the ones in my previous pull request minus the alterations to 'do'.
