### PR TITLE
[contrib/lua] cjdlua utilily prints useful info.

### DIFF
--- a/contrib/lua/cjdlua
+++ b/contrib/lua/cjdlua
@@ -131,7 +131,7 @@ meshLua_cmd = {
 		function(x)
 
 			local dkjson = require "dkjson"  -- http://dkolf.de/src/dkjson-lua.fsl/home
-			local cjdroute = io.open("/etc/cjdroute.conf")
+			local cjdroute = io.open(confpath)
 			local conf, pos, err = dkjson.decode(cjdroute:read("*a"), 1, nil)
 
 			local page = 0


### PR DESCRIPTION
depends:
apt-get install lua5.1 luarocks 
luarocks install bencode 
luarocks install dkjson
luarocks install luasocket
luarocks install sha2

Then in ./cjdns/contrib/lua  simply run either ./cjdlua or ./cjdlua l
![cjdlua](https://cloud.githubusercontent.com/assets/5460439/3579564/1af44a38-0bc3-11e4-9acb-4ada6c5af697.png)
