### PR TITLE
Fixes #606

### DIFF
--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=A routing engine designed for security, scalability, speed and ease of use
 Wants=network.target
-Before=network.target
+After=network.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
This fixes #606 – `cjdroute` should be started after network is up.
