### PR TITLE
Changed the location of the created tun device to where it's expected

### DIFF
--- a/contrib/android/cjdroid/install.sh
+++ b/contrib/android/cjdroid/install.sh
@@ -7,11 +7,8 @@ if [ ! "${0%/*}" = $(echo $0 | sed 's|^.*/||') ]; then cd "${0%/*}"; fi
 if [ ! `whoami` = "root" ]; then echo "Please run this script as root"; exit 1; fi
 
 # Check that /dev/net/tun exists and create it if it doesn't
-if [ ! -c /dev/net/tun ]; then
-    if [ ! -d /dev/net ]; then
-        mkdir /dev/net
-    fi
-    mknod /dev/net/tun c 10 200
+if [ ! -c /dev/tun ]; then
+    mknod /dev/tun c 10 200
 fi
 
 # Remount /system read/write


### PR DESCRIPTION
@lgierth noticed the new location for the tun device on Android (at least according to where **cjdroute** looks for it) is `/dev/tun` and not `/dev/net/tun`, and this update to my previous pull request changes the location to the correct one.
