### PR TITLE
Remove extra newlines in genconf

### DIFF
--- a/admin/angel/cjdroute2.c
+++ b/admin/angel/cjdroute2.c
@@ -165,8 +165,6 @@ static int genconf(struct Random* rand)
            "        \"password\": \"%s\"\n", adminPassword);
     printf("    },\n"
            "\n"
-           "\n\n" // TODO(cjd): Why is this needed and where are these newlines going?!!
-           "\n"
            "    // Interfaces to connect to the switch core.\n"
            "    \"interfaces\":\n"
            "    {\n"


### PR DESCRIPTION
> where are these newlines going?

they aren't going anywhere, so I think this isn't needed anymore. If an ugly hack requires these lines I think we should fix the hack instead
