### PR TITLE
Introduce better handling of codestyle errors

### DIFF
--- a/node_build/builder.js
+++ b/node_build/builder.js
@@ -834,6 +834,7 @@ var configure = module.exports.configure = function (params, configFunc) {
     var packStage = function () {};
     var successStage = function () {};
     var failureStage = function () {};
+    var invalidStage = function () {};
     var completeStage = function () {};
 
     nThen(function (waitFor) {
@@ -997,7 +998,7 @@ var configure = module.exports.configure = function (params, configFunc) {
                             linter(fileName, ret, waitFor(function (out, isErr) {
                                 if (isErr) {
                                     debug(out);
-                                    builder.failure = true;
+                                    builder.invalid = true;
                                 }
                             }));
                         });
@@ -1059,9 +1060,17 @@ var configure = module.exports.configure = function (params, configFunc) {
 
     }).nThen(function (waitFor) {
 
-        if (builder.failure) { return; }
+        if (builder.failure || builder.invalid) {
+            return;
+        }
 
         stage(successStage, builder, waitFor);
+
+    }).nThen(function (waitFor) {
+
+        if (!builder.invalid) { return; }
+
+        stage(invalidStage, builder, waitFor);
 
     }).nThen(function (waitFor) {
 
@@ -1080,6 +1089,7 @@ var configure = module.exports.configure = function (params, configFunc) {
         test:     function (x) { testStage = x;     return out; },
         pack:     function (x) { packStage = x;     return out; },
         failure:  function (x) { failureStage = x;  return out; },
+        invalid:  function (x) { invalidStage = x;  return out; },
         success:  function (x) { successStage = x;  return out; },
         complete: function (x) { completeStage = x; return out; },
     };

--- a/node_build/make.js
+++ b/node_build/make.js
@@ -368,10 +368,16 @@ Builder.configure({
 
     console.log('\033[1;31mFailed to build cjdns.\033[0m');
 
+}).invalid(function (builder, waitFor) {
+
+    console.log('\033[1;33mBuild compiled successfully but there was some errors.\033[0m');
+
 }).complete(function (builder, waitFor) {
 
     if (builder.failure) {
         process.exit(1);
+    } else if (builder.invalid) {
+        process.exit(2);
     }
 
 });


### PR DESCRIPTION
Currently the build completely stops when a section of code fails the Codestyle check, even though it is perfectly compilable.
This pull request changes:

```
[...]
Checking codestyle
admin/angel/Core.c:1  missing header
/* vim: set expandtab ts=4 sw=4: */
/* vim: set expandtab ts=9999 sw=asdasdasdasdqwde: */

Failed to build cjdns.
Total build time: 108000ms.
```

into:

```
[...]
Checking codestyle
admin/angel/Core.c:1  missing header
/* vim: set expandtab ts=4 sw=4: */
/* vim: set expandtab ts=9999 sw=asdasdasdasdqwde: */

Test 593ms
Pack 16ms
Get mtimes 9ms
Save State 96ms
Build compiled successfully but there was some errors.
Total build time: 10000ms.
```
