### PR TITLE
Some janitor stuff

### DIFF
--- a/dht/dhtcore/Janitor.c
+++ b/dht/dhtcore/Janitor.c
@@ -63,6 +63,9 @@ struct Janitor
     // Used to discover new nodes.
     struct RumorMill* nodeMill;
 
+    // Just used to keep track of nodes that we need to check on for DHT health.
+    struct RumorMill* searchMill;
+
     struct Timeout* timeout;
 
     struct Log* logger;
@@ -185,26 +188,22 @@ static void searchNoDupe(uint8_t target[Address_SEARCH_TARGET_SIZE], struct Jani
 }
 
 /**
- * For a Distributed Hash Table to work, each node must know a valid next hop in the search,
- * if such a thing exists.
+ * For a Distributed Hash Table to work, each node must know a valid next hop for every possible
+ * lookup, unless no such node exists in the network (i.e. the final hop is either us or offline).
  *
- * In a Kademlia DHT, can be done by organizing nodes into k-buckets. These are collections
- * of k nodes for which the first n bits of your node IDs match. Among other things, k-buckets
- * allow a node to identify holes in their lookup table and fill them. If the nth bucket is empty,
- * it means your node knows of no valid next hop for any key matching the first n bits of your
- * address and differing in bit n+1.
- *
- * Without going to the trouble of organizing nodes in the buckets, this function iterates
- * bitwise over keyspace, to identify the same kind of routing holes.
- * It then dispatches a search for the first (largest) such hole in keyspace that it finds.
+ * This function fills a list (RumorMill) of addresses which characterize a valid next hop.
  */
-static void plugLargestKeyspaceHole(struct Janitor* janitor, bool force)
+static void keyspaceMaintainenceGlobal(struct Janitor* janitor)
 {
-    struct Address addr = *janitor->nodeStore->selfAddress;
+    if (janitor->searchMill->count) {
+        // We still have nodes to check from earlier maintenance cycles.
+        // Don't do anything.
+        return;
+    }
 
     int byte = 0;
     int bit = 0;
-    uint8_t holeDepth = 0;
+    bool foundHole = false;
     for (uint8_t i = 0; i < 128 ; i++) {
         // Bitwise walk across keyspace
         if (63 < i && i < 72) {
@@ -212,88 +211,69 @@ static void plugLargestKeyspaceHole(struct Janitor* janitor, bool force)
             continue;
         }
 
-        // Figure out which bit of the address to flip for this step in keyspace.
+        // Figure out which bit of our address to flip for this step in keyspace.
         // This looks ugly because of the rot64 done in distance calculations.
         if (i < 64) { byte = 8 + (i/8); }
         else        { byte = (i/8) - 8; }
         bit = (i % 8);
 
-        // Flip that bit.
+        // Create an address with that bit flipped.
+        struct Address addr = *janitor->nodeStore->selfAddress;
         addr.ip6.bytes[byte] = addr.ip6.bytes[byte] ^ (0x80 >> bit);
 
-        // See if we know a valid next hop.
-        struct Node_Two* n = RouterModule_lookup(addr.ip6.bytes, janitor->routerModule);
+        // Keep the rumorMill code happy. We only use this for searches, so it's OK.
+        addr.path = i;
+        addr.key[0] = addr.key[0] ^ 0x80;
 
-        if (n) {
-            // We do know a valid next hop, so flip the bit back and continue.
-            addr.ip6.bytes[byte] = addr.ip6.bytes[byte] ^ (0x80 >> bit);
-            continue;
+        // See if we know a valid next hop.
+        struct Node_Two* node = RouterModule_lookup(addr.ip6.bytes, janitor->routerModule);
+
+        if (!node) {
+            if (foundHole) {
+                // We don't already know a node for this keyspace address, and we've
+                // already found at least one hole.
+                continue;
+            } else {
+                // This is the first hole we've found.
+                // Signal that we've found it, so we know to break when find more.
+                foundHole = true;
+            }
+        } else {
+            if (foundHole) {
+                // Oops, it looks like that last hole was one that opened up in the
+                // middle of keyspace.
+                // So we need to keep checking later holes.
+                foundHole = false;
+            }
         }
 
-        // We found a hole! Exit loop and let the search trigger.
-        holeDepth = i;
-        break;
-    }
-
-    // Search for a node that satisfies the address requirements to fill the hole.
-    if (holeDepth != janitor->keyspaceHoleDepthCounter || force) {
-        Log_debug(janitor->logger, "Setting keyspaceHoleDepthCounter [%u]", holeDepth);
-        janitor->keyspaceHoleDepthCounter = holeDepth;
-        searchNoDupe(addr.ip6.bytes, janitor);
+        // Add to mill.
+        RumorMill_addNode(janitor->searchMill, &addr);
     }
 }
 
-// Counterpart to plugLargestKeyspaceHole, used to refresh reach of known routes with a search.
-// This also finds redundant routes for that area of keyspace, which helps the DHT some.
-static void keyspaceMaintainence(struct Janitor* janitor)
+/* Searches for a valid next hop or better route to existing hop for each node in the searchMill */
+static void keyspaceMaintainenceLocal(struct Janitor* janitor)
 {
-    struct Address addr = *janitor->nodeStore->selfAddress;
-
-    int byte = 0;
-    int bit = 0;
-
-    // Restart cycle if we've already finished it.
-    if (janitor->keyspaceMaintainenceCounter > 127) {
-        janitor->keyspaceMaintainenceCounter = 0;
+    if (janitor->searches) {
+        // Searches are expensive, wait till they finish before doing anything.
+        return;
     }
-    for (;janitor->keyspaceMaintainenceCounter < 128;
-          janitor->keyspaceMaintainenceCounter++) {
-
-        // Just to make referring to this thing quicker
-        int i = janitor->keyspaceMaintainenceCounter;
-
-        if (63 < i && i < 72) {
-            // We want to leave the 0xfc alone
-            continue;
-        }
-
-        // Figure out which bit of the address to flip for this step in keyspace.
-        // This looks ugly because of the rot64 done in distance calculations.
-        if (i < 64) { byte = 8 + (i/8); }
-        else        { byte = (i/8) - 8; }
-        bit = (i % 8);
-
-        // Flip that bit.
-        addr.ip6.bytes[byte] = addr.ip6.bytes[byte] ^ (0x80 >> bit);
-
-        // See if we know a valid next hop.
-        struct Node_Two* n = RouterModule_lookup(addr.ip6.bytes, janitor->routerModule);
-
-        if (n) {
-            // Start the next search 1 step further into keyspace.
-            janitor->keyspaceMaintainenceCounter = i+1;
-            break;
-        }
-
-        // Clean up address and move further into keyspace.
-        addr.ip6.bytes[byte] = addr.ip6.bytes[byte] ^ (0x80 >> bit);
-        continue;
+    struct Address addr;
+    if (!RumorMill_getNode(janitor->searchMill, &addr)) {
+        // There's nothing to search for.
+        return;
     }
 
-    // Search for a node that satisfies the address requirements to fill the hole.
-    // Should end up self-searching in the event that we're all the way through keyspace.
-    searchNoDupe(addr.ip6.bytes, janitor);
-
+    struct Node_Two* node = RouterModule_lookup(addr.ip6.bytes, janitor->routerModule);
+    if (node) {
+        // We know a valid next hop, so let's ping it to check its health.
+        // TODO(arceliar): try to find better path? (how?)
+        RouterModule_pingNode(&node->address, 0, janitor->routerModule, janitor->allocator);
+    } else {
+        // We don't know a valid next hop, so let's try to find one.
+        searchNoDupe(addr.ip6.bytes, janitor);
+    }
 }
 
 static void peersResponseCallback(struct RouterModule_Promise* promise,
@@ -422,6 +402,21 @@ static struct Node_Two* getRandomNode(struct Random* rand, struct NodeStore* sto
     return node;
 }
 
+static void getPeersMill(struct Janitor* janitor, struct Address* addr)
+{
+    addr->path = NodeStore_optimizePath(janitor->nodeStore, addr->path);
+    if (NodeStore_optimizePath_INVALID != addr->path) {
+        struct RouterModule_Promise* rp =
+            RouterModule_getPeers(addr,
+                                  Random_uint32(janitor->rand),
+                                  0,
+                                  janitor->routerModule,
+                                  janitor->allocator);
+        rp->callback = peersResponseCallback;
+        rp->userData = janitor;
+    }
+}
+
 static void maintanenceCycle(void* vcontext)
 {
     struct Janitor* const janitor = Identity_check((struct Janitor*) vcontext);
@@ -445,45 +440,22 @@ static void maintanenceCycle(void* vcontext)
 
     if (RumorMill_getNode(janitor->rumorMill, &addr)) {
         // ping a node from the externally accessible queue
-        addr.path = NodeStore_optimizePath(janitor->nodeStore, addr.path);
-        if (NodeStore_optimizePath_INVALID != addr.path) {
-            struct RouterModule_Promise* rp =
-                RouterModule_getPeers(&addr,
-                                      Random_uint32(janitor->rand),
-                                      0,
-                                      janitor->routerModule,
-                                      janitor->allocator);
-            rp->callback = peersResponseCallback;
-            rp->userData = janitor;
-
-            #ifdef Log_DEBUG
-                uint8_t addrStr[60];
-                Address_print(addrStr, &addr);
-                Log_debug(janitor->logger, "Pinging possible node [%s] from "
-                                           "external RumorMill", addrStr);
-            #endif
-        }
-
+        getPeersMill(janitor, &addr);
+        #ifdef Log_DEBUG
+            uint8_t addrStr[60];
+            Address_print(addrStr, &addr);
+            Log_debug(janitor->logger, "Pinging possible node [%s] from "
+                                       "external RumorMill", addrStr);
+        #endif
     } else if (RumorMill_getNode(janitor->linkMill, &addr)) {
         // ping a link-splitting node from the high-priority ping queue
-        addr.path = NodeStore_optimizePath(janitor->nodeStore, addr.path);
-        if (NodeStore_optimizePath_INVALID != addr.path) {
-            struct RouterModule_Promise* rp =
-                RouterModule_getPeers(&addr,
-                                      Random_uint32(janitor->rand),
-                                      0,
-                                      janitor->routerModule,
-                                      janitor->allocator);
-            rp->callback = peersResponseCallback;
-            rp->userData = janitor;
-
-            #ifdef Log_DEBUG
-                uint8_t addrStr[60];
-                Address_print(addrStr, &addr);
-                Log_debug(janitor->logger, "Pinging possible node [%s] from "
-                                           "link-finding RumorMill", addrStr);
-            #endif
-        }
+        getPeersMill(janitor, &addr);
+        #ifdef Log_DEBUG
+            uint8_t addrStr[60];
+            Address_print(addrStr, &addr);
+            Log_debug(janitor->logger, "Pinging possible node [%s] from "
+                                       "link-finding RumorMill", addrStr);
+        #endif
 
     } else if (Random_uint32(janitor->rand) % 4) {
         // 75% of the time, ping a random link from a random node.
@@ -517,44 +489,24 @@ static void maintanenceCycle(void* vcontext)
             {
                 addr.path = path;
             }
-            addr.path = NodeStore_optimizePath(janitor->nodeStore, addr.path);
-            if (NodeStore_optimizePath_INVALID != addr.path) {
-                struct RouterModule_Promise* rp = RouterModule_getPeers(&addr,
-                                                    Random_uint32(janitor->rand),
-                                                    0,
-                                                    janitor->routerModule,
-                                                    janitor->allocator);
-                rp->callback = peersResponseCallback;
-                rp->userData = janitor;
-                #ifdef Log_DEBUG
-                    uint8_t addrStr[60];
-                    Address_print(addrStr, &addr);
-                    Log_debug(janitor->logger, "Pinging random node link [%s] for maintenance.",
-                                                                                       addrStr);
-                #endif
-            }
+            getPeersMill(janitor, &addr);
+            #ifdef Log_DEBUG
+                uint8_t addrStr[60];
+                Address_print(addrStr, &addr);
+                Log_debug(janitor->logger, "Pinging random node link [%s] for maintenance.",
+                                                                                   addrStr);
+            #endif
         }
 
     } else if (RumorMill_getNode(janitor->nodeMill, &addr)) {
         // ping a node from the low-priority ping queue
-        addr.path = NodeStore_optimizePath(janitor->nodeStore, addr.path);
-        if (NodeStore_optimizePath_INVALID != addr.path) {
-            struct RouterModule_Promise* rp =
-                RouterModule_getPeers(&addr,
-                                      Random_uint32(janitor->rand),
-                                      0,
-                                      janitor->routerModule,
-                                      janitor->allocator);
-            rp->callback = peersResponseCallback;
-            rp->userData = janitor;
-
-            #ifdef Log_DEBUG
-                uint8_t addrStr[60];
-                Address_print(addrStr, &addr);
-                Log_debug(janitor->logger, "Pinging possible node [%s] from "
-                                           "node-finding RumorMill", addrStr);
-            #endif
-        }
+        getPeersMill(janitor, &addr);
+        #ifdef Log_DEBUG
+            uint8_t addrStr[60];
+            Address_print(addrStr, &addr);
+            Log_debug(janitor->logger, "Pinging possible node [%s] from "
+                                       "node-finding RumorMill", addrStr);
+        #endif
     }
 
     // random search
@@ -567,14 +519,14 @@ static void maintanenceCycle(void* vcontext)
     // If the best next node doesn't exist or has 0 reach, run a local maintenance search.
     if (n == NULL || Node_getReach(n) == 0) {
         //search(addr.ip6.bytes, janitor);
-        plugLargestKeyspaceHole(janitor, true);
-        return;
+        //plugLargestKeyspaceHole(janitor, true);
+        //return;
 
     } else {
         checkPeers(janitor, n);
     }
 
-    plugLargestKeyspaceHole(janitor, false);
+    keyspaceMaintainenceLocal(janitor);
 
     Log_debug(janitor->logger,
               "Global Mean Response Time: %u nodes [%d] links [%d]",
@@ -584,8 +536,7 @@ static void maintanenceCycle(void* vcontext)
 
     if (now > janitor->timeOfNextGlobalMaintainence) {
         //search(addr.ip6.bytes, janitor);
-        plugLargestKeyspaceHole(janitor, true);
-        keyspaceMaintainence(janitor);
+        keyspaceMaintainenceGlobal(janitor);
         splitLinks(janitor);
         janitor->timeOfNextGlobalMaintainence += janitor->globalMaintainenceMilliseconds;
     }
@@ -622,6 +573,8 @@ struct Janitor* Janitor_new(uint64_t localMaintainenceMilliseconds,
     janitor->linkMill = RumorMill_new(janitor->allocator, janitor->nodeStore->selfAddress, 64);
 
     janitor->nodeMill = RumorMill_new(janitor->allocator, janitor->nodeStore->selfAddress, 64);
+
+    janitor->searchMill = RumorMill_new(janitor->allocator, janitor->nodeStore->selfAddress, 64);
 
     janitor->timeOfNextGlobalMaintainence = Time_currentTimeMilliseconds(eventBase);
 

--- a/dht/dhtcore/RumorMill.c
+++ b/dht/dhtcore/RumorMill.c
@@ -44,9 +44,10 @@ static inline bool hasNode(struct RumorMill* mill, struct Address* addr)
     struct RumorMill_pvt* rm = Identity_check((struct RumorMill_pvt*) mill);
     for (int i = 0; i < rm->pub.count; i++) {
         if (rm->addresses[i].path == addr->path ||
-            !Bits_memcmp(&rm->addresses[i], addr->ip6.bytes, Address_SEARCH_TARGET_SIZE)) {
+            !Bits_memcmp(&rm->addresses[i], addr->ip6.bytes, Address_SEARCH_TARGET_SIZE))
+        {
             return true;
-            }
+        }
     }
     return false;
 }

--- a/dht/dhtcore/SearchRunner.c
+++ b/dht/dhtcore/SearchRunner.c
@@ -150,8 +150,8 @@ static void searchReplyCallback(struct RouterModule_Promise* promise,
         }
 
         struct Node_Two* nn =
-            NodeStore_closestNode(search->runner->nodeStore, nodeList->elems[i].path);
-        if (!nn || Bits_memcmp(nn->address.key, nodeList->elems[i].key, 32)) {
+            RouterModule_lookup(nodeList->elems[i].ip6.bytes, search->runner->router);
+        if (!nn) {
             RumorMill_addNode(search->runner->rumorMill, &nodeList->elems[i]);
         }
 


### PR DESCRIPTION
Mainly code cleanup,  mainly in the janitor.

There were some spots of duplicate code that I didn't like the look of (namely to do with checking all the different RumorMills in the janitor), so I refactored the ugly part into a separate function.

Rewrote the keyspace maintainance part. Instead of having 2 nearly identical functions, it's now 2 different functions. One runs during the global cycle, and queues up a list of important addresses (selfNode address with 1 bit flipped) into yet another RumorMill, if the mill is empty. The other function runs during the local maint cycle, and just pops items form the mill to search for (or ping if a valid next hop already exists). Since the mill empties every 30 seconds on such a small network, this basically trades 2 searches (max length 8), for 1 search (max length 8) and around 9-10 pings, for a network our current size. Expect number of pings to increase logarithmically with network size, capping at most one per second. This makes sure that nodes which are important to keyspace are checked about once every 30 seconds (more like once/minute if the network ever becomes huge), as opposed to once every ~5 minutes before.
