### PR TITLE
tons of improvements, cjdctl has restart, install.sh has uninstall, help

### DIFF
--- a/contrib/android/cjdroid/files/99cjdroute
+++ b/contrib/android/cjdroid/files/99cjdroute
@@ -3,8 +3,8 @@
 # Set the main directory for things to run (if changed, also change in cjdaemon and cjdctl)
 CJDPATH="/sdcard/cjdns"
 
-if [ -f "${CJDPATH}/.cjdaemon.pid" ]; then
-    rm "${CJDPATH}/.cjdaemon.pid"
+if [ -f "$CJDPATH"/.cjdaemon.pid ]; then
+    rm "$CJDPATH"/.cjdaemon.pid
 fi
 
 cjdaemon

--- a/contrib/android/cjdroid/files/cjdaemon
+++ b/contrib/android/cjdroid/files/cjdaemon
@@ -5,54 +5,68 @@ CJDPATH="/sdcard/cjdns"
 
 # Function to output status messages and log if configured to do so
 logmessage() {
-    if [ -n "$CJDLOG" ]; then echo "$(date) - $1" >> "${CJDPATH}/cjdaemon.log"; fi
+    if [ -n "$CJDLOG" ]; then
+        echo "`date` - $1" >> "$CJDPATH"/cjdaemon.log
+    fi
 }
 
 # Create the daemon folder if it doesn't exist
-if [ ! -e "$CJDPATH" ]; then mkdir -p "$CJDPATH" || exit 1; fi
+if [ ! -e "$CJDPATH" ]; then
+    install -d "$CJDPATH" \
+        || exit 1
+fi
 
 # Fail if the daemon is already running
-if [ -f "${CJDPATH}/.cjdaemon.pid" ]; then
-    if [ -d "/proc/$(cat ${CJDPATH}/.cjdaemon.pid)" ]; then
+if [ -f "$CJDPATH"/.cjdaemon.pid ]; then
+    if [ -d /proc/`cat "$CJDPATH"/.cjdaemon.pid` ]; then
         logmessage "Error! Daemon already running"
         exit 1
     fi
 fi
 
 # Set a pid file for the daemon so we know what to kill if it starts causing issues
-echo "$$" > "${CJDPATH}/.cjdaemon.pid"
+echo "$$" > "$CJDPATH"/.cjdaemon.pid
 
 # Create cjdaemon.conf if it's missing
-if [ ! -f "${CJDPATH}/cjdaemon.conf" ]; then
-    touch "${CJDPATH}/cjdaemon.conf" || exit 1
-    echo -e 'CJDCFG="cjdroute.conf"\nCJDLOG=0' > "${CJDPATH}/cjdaemon.conf"
+if [ ! -f "$CJDPATH"/cjdaemon.conf ]; then
+    touch "$CJDPATH"/cjdaemon.conf \
+        || exit 1
+
+    echo -e 'CJDCFG="cjdroute.conf"\nCJDLOG=0' \
+        > "$CJDPATH"/cjdaemon.conf
 fi
 
 # Source cjdaemon.conf to load user settings
-source "${CJDPATH}/cjdaemon.conf"
+source "$CJDPATH"/cjdaemon.conf
 
 # Set $CJDCFG to the default if it wasn't set by cjdaemon.conf
-if [ -z "$CJDCFG" ]; then CJDCFG="cjdroute.conf"; fi
+if [ -z "$CJDCFG" ]; then
+    CJDCFG="cjdroute.conf"
+fi
 
 # Create the log if it doesn't exist, and if it can't be created disable logging
 if [ -n "$CJDLOG" ]; then
-    if [ ! -f "${CJDPATH}/cjdaemon.log" ]; then
-        touch "${CJDPATH}/cjdaemon.log" || unset CJDLOG
+    if [ ! -f "$CJDPATH"/cjdaemon.log ]; then
+        touch "$CJDPATH"/cjdaemon.log \
+            || unset CJDLOG
     fi
 fi
 
 # Function used to start cjdroute
 cjdstart() {
     # Exit if the lock file is missing
-    if [ ! -f "${CJDPATH}/.lock" ]; then exit; fi
+    if [ ! -f "$CJDPATH"/.lock ]; then
+        exit 0
+    fi
 
     # Start cjdroute and output/log results
     if [ -f "${CJDPATH}/${CJDCFG}" ]; then
-        if [ $(pgrep cjdroute | wc -l) -eq 0 ]; then
+        if [ `pgrep cjdroute | wc -l` -eq 0 ]; then
             LOGMSG="Running: cjdroute < ${CJDPATH}/${CJDCFG}..."
             cjdroute < "${CJDPATH}/${CJDCFG}" &> /dev/null 2>&1
             sleep 1
-            if [ $(pgrep cjdroute | wc -l) -gt 0 ]; then
+
+            if [ `pgrep cjdroute | wc -l` -gt 0 ]; then
                 LOGMSG="${LOGMSG} Success!"
             else
                 LOGMSG="${LOGMSG} Error! Failed to start cjdroute"
@@ -63,6 +77,7 @@ cjdstart() {
     else
         LOGMSG="${LOGMSG} Error! Failed to start cjdroute, config missing @ ${CJDPATH}/${CJDCFG}"
     fi
+
     logmessage "$LOGMSG"
     unset LOGMSG
 }
@@ -70,21 +85,25 @@ cjdstart() {
 # Function used to stop cjdroute
 cjdstop() {
     # Exit if the lock file is missing
-    if [ ! -f "${CJDPATH}/.lock" ]; then exit; fi
+    if [ ! -f "$CJDPATH"/.lock ]; then
+        exit 0
+    fi
 
     # Kill cjdroute and output/log results
-    if [ $(pgrep cjdroute | wc -l) -gt 0 ]; then
+    if [ `pgrep cjdroute | wc -l` -gt 0 ]; then
         LOGMSG="Running: killall cjdroute..."
         killall cjdroute
         sleep 1
-        if [ $(pgrep cjdroute | wc -l) -eq 0 ]; then
+
+        if [ `pgrep cjdroute | wc -l` -eq 0 ]; then
             LOGMSG="${LOGMSG} Success!"
         else
-            LOGMSG="${LOGMSG} Error: Failed to stop cjdroute"
+            LOGMSG="${LOGMSG} Error! Failed to stop cjdroute"
         fi
     else
         LOGMSG="${LOGMSG} Error! Failed to stop cjdroute, already stopped"
     fi
+
     logmessage "$LOGMSG"
     unset LOGMSG
 }
@@ -94,7 +113,6 @@ while :; do
     # Wait until the phone is awake, then start cjdroute
     cat /sys/power/wait_for_fb_wake > /dev/null
     cjdstart
-
     sleep 1
 
     # Wait until the phone sleeps, then stop cjdns

--- a/contrib/android/cjdroid/files/cjdctl
+++ b/contrib/android/cjdroid/files/cjdctl
@@ -1,40 +1,48 @@
 #!/system/bin/sh
 
-# Set the main directory for things to run (if changed, also change in cjdaemon and 99cjdroute)
+# Config and runtime directory (if changed, also change in cjdaemon and 99cjdroute)
 CJDPATH="/sdcard/cjdns"
 
 # Set the name of this script
-APPNAME=$(echo -n "$0" | grep -o -e "[^\/]*$")
+APPNAME="${0##*/}"
 
 # Exit with an error if the user isn't root
-if [ ! $(whoami) = "root" ]; then
+if [ ! `whoami` = "root" ]; then
     echo "Error: ${APPNAME} must be run as root"
     exit 1
 fi
 
 # Create the daemon folder if it doesn't exist
-if [ ! -e "$CJDPATH" ]; then mkdir -p "$CJDPATH" || exit 1; fi
+if [ ! -e "$CJDPATH" ]; then
+    install -d "$CJDPATH" || exit 1
+fi
 
 # Source cjdaemon.conf to load user settings if it exists
-if [ -f "${CJDPATH}/cjdaemon.conf" ]; then source "${CJDPATH}/cjdaemon.conf"; fi
+if [ -f "$CJDPATH"/cjdaemon.conf ]; then
+    source "$CJDPATH"/cjdaemon.conf
+fi
 
 # Set $CJDCFG to the default if it wasn't set by cjdaemon.conf
-if [ -z "$CJDCFG" ]; then CJDCFG="cjdroute.conf"; fi
+if [ -z "$CJDCFG" ]; then
+    CJDCFG="cjdroute.conf"
+fi
 
 # Create the lock file and start (or if running, restart) cjdaemon
 enable_cjdaemon() {
     echo -n "${APPNAME}: Enabling cjdns... "
 
     # Create the lock file, enabling cjdaemon
-    if [ ! -f "${CJDPATH}/.lock" ]; then touch "${CJDPATH}/.lock"; fi
+    if [ ! -f "$CJDPATH"/.lock ]; then
+        touch "$CJDPATH"/.lock
+    fi
 
     # If running, kill cjdaemon (it'll start cjdroute when restarted)
-    if [ -f "${CJDPATH}/.cjdaemon.pid" ]; then
-        if [ -d "/proc/$(cat ${CJDPATH}/.cjdaemon.pid)" ]; then
-            kill $(cat "${CJDPATH}/.cjdaemon.pid")
+    if [ -f "$CJDPATH"/.cjdaemon.pid ]; then
+        if [ -d /proc/`cat "$CJDPATH"/.cjdaemon.pid` ]; then
+            kill `cat "$CJDPATH"/.cjdaemon.pid`
             sleep 1
         fi
-        rm "${CJDPATH}/.cjdaemon.pid"
+        rm "$CJDPATH"/.cjdaemon.pid
     fi
 
     # Start cjdaemon (which will start cjdroute if the phone is awake)
@@ -42,8 +50,8 @@ enable_cjdaemon() {
     sleep 1
 
     # Exit successfully if cjdaemon started, otherwise exit with an error
-    if [ -f "${CJDPATH}/.cjdaemon.pid" ]; then
-        if [ -d "/proc/$(cat ${CJDPATH}/.cjdaemon.pid)" ]; then
+    if [ -f "$CJDPATH"/.cjdaemon.pid ]; then
+        if [ -d /proc/`cat "$CJDPATH"/.cjdaemon.pid` ]; then
             echo "Done!"
             exit 0
         fi
@@ -57,23 +65,25 @@ disable_cjdaemon() {
     echo -n "${APPNAME}: Disabling cjdns... "
 
     # Remove the lock file, disabling cjdaemon
-    if [ -f "${CJDPATH}/.lock" ]; then rm "${CJDPATH}/.lock"; fi
+    if [ -f "$CJDPATH"/.lock ]; then
+        rm "$CJDPATH"/.lock
+    fi
 
     # If cjdaemon is running, kill it
-    if [ -f "${CJDPATH}/.cjdaemon.pid" ]; then
-        if [ -d "/proc/$(cat ${CJDPATH}/.cjdaemon.pid)" ]; then
-            kill $(cat "${CJDPATH}/.cjdaemon.pid")
+    if [ -f "$CJDPATH"/.cjdaemon.pid ]; then
+        if [ -d /proc/`cat "$CJDPATH"/.cjdaemon.pid` ]; then
+            kill `cat "$CJDPATH"/.cjdaemon.pid`
             sleep 1
         fi
-        rm "${CJDPATH}/.cjdaemon.pid"
+        rm "$CJDPATH"/.cjdaemon.pid
     fi
 
     # If cjdroute is running, kill it
-    if [ $(pgrep cjdroute | wc -l) -gt 0 ]; then
+    if [ `pgrep cjdroute | wc -l` -gt 0 ]; then
         killall cjdroute
         sleep 1
 
-        if [ ! $(pgrep cjdroute | wc -l) -eq 0 ]; then
+        if [ ! `pgrep cjdroute | wc -l` -eq 0 ]; then
             echo "Error! cjdroute still running"
             exit 1
         fi
@@ -83,16 +93,21 @@ disable_cjdaemon() {
 
 # Parse commandline arguments and behave accordingly
 case "$1" in
-    e|enable)
+    e|-e|enable|--enable)
         enable_cjdaemon
         ;;
-    d|disable)
+    d|-d|disable|--disable)
         disable_cjdaemon
+        ;;
+    r|-r|restart|--restart)
+        disable_cjdaemon
+        enable_cjdaemon
         ;;
     *)
         echo -e "Usage:\n\t${APPNAME} [option]\n"
         echo -e "Options:"
-        echo -e "\te|enable: Start cjdns and enable at boot"
-        echo -e "\td|disable: Stop cjdns and disable at boot"
+        echo -e "\te|enable: start cjdns and enable at boot"
+        echo -e "\td|disable: stop cjdns and disable at boot"
+        echo -e "\tr|restart: stop+disable, then start+enable cjdns"
         ;;
 esac

--- a/contrib/android/cjdroid/install.sh
+++ b/contrib/android/cjdroid/install.sh
@@ -1,30 +1,196 @@
 #!/system/bin/sh
 
-# Change to the script directory
-if [ ! "${0%/*}" = $(echo $0 | sed 's|^.*/||') ]; then cd "${0%/*}"; fi
+# Config and runtime directory (if changed, also change in cjdaemon and 99cjdroute)
+CJDPATH="/sdcard/cjdns"
 
-# Fail if user isn't root
-if [ ! `whoami` = "root" ]; then echo "Please run this script as root"; exit 1; fi
+# Partition/disk the $BINDIR and $INITDIR are on
+SYSDISK="/system"
+
+# The folder to place executables (should be in $PATH)
+BINDIR="$SYSDISK"/bin
+
+# The init.d folder the version of Android on your device expcets to see init.d scripts
+INITDIR="$SYSDISK"/etc/init.d
+
+# Change to the script directory
+cd `dirname "$0"`
+
+# Set the name of this script
+APPNAME="${0##*/}"
+
+function _sysrw() {
+    # Remount $SYSDISK read/write if necessary
+    mount | grep " $SYSDISK " | grep ro >/dev/null \
+        && REMOUNT=1 \
+        && mount -o rw,remount "$SYSBLOCK" "$SYSDISK"
+
+    if [ "$REMOUNT" = 1 ]; then
+        mount | grep " $SYSDISK " | grep ro >/dev/null \
+            && echo -e "Error: couldn't remount ${SYSDISK} read/write\n" \
+            && exit 1
+    fi
+}
+
+function _sysro() {
+    # Remount $SYSDISK read-only if it was previously remounted
+    if [ "$REMOUNT" = 1 ]; then
+        mount | grep " $SYSDISK " | grep rw >/dev/null \
+            && mount -o ro,remount "$SYSBLOCK" "$SYSDISK"
+
+        mount | grep " $SYSDISK " | grep rw >/dev/null \
+            && echo "Error: couldn't remount ${SYSDISK} read-only"
+    fi
+}
+
+# The help output functionality
+if [ -n "$1" ]; then
+    if [ "$1" = "-h" -o "$1" = "--help" ]; then
+        echo -e "\nUsage:\n\t${APPNAME} [option]\n"
+        echo -e "\t* This script requires root permissions to run"
+        echo -e "\t* Run this script with no arguments to install cjdns"
+        echo -e "\t* Install cjdns again after flashing new/upated ROMs"
+        echo -e "\nOptions:"
+        echo -e "\t-u|--uninstall: uninstall from ${SYSDISK}"
+        echo -e "\t-h|--help: display this help output\n"
+        exit 0
+    fi
+fi
+
+# Fail if user isn't root (it's needed from here on out)
+if [ ! `whoami` = "root" ]; then
+    echo
+    echo "Error: this script must be run as root"
+    echo
+    exit 1
+fi
 
 # Check that /dev/net/tun exists and create it if it doesn't
 if [ ! -c /dev/tun ]; then
     mknod /dev/tun c 10 200
 fi
 
-# Remount /system read/write
-SYSTEM=`mount | grep " /system " | grep -oe "^[^\ ]*"`
-if [ ! -e "$SYSTEM" ]; then echo "The device /system is mounted on could not be detected"; exit 1; fi
-mount -o rw,remount $SYSTEM /system
+# Set the device block for the system partition
+SYSBLOCK=`mount | grep " $SYSDISK " | grep -oe "^[^\ ]*" | head -n 1`
+if [ ! -e "$SYSBLOCK" ]; then
+    echo
+    echo "Error: Couldn't detect the device ${SYSDISK} is mounted on"
+    echo
+    exit 1
+fi
 
-# Copy cjdns-related-files to /system
-cp files/cjdaemon /system/bin/
-cp files/cjdctl /system/bin/
-cp files/cjdroute /system/bin/
-cp files/99cjdroute /system/etc/init.d/
+# Stop cjdroute if it's running
+if [ `pgrep cjdroute | wc -l` -gt 0 ]; then
+    echo
+    echo "Killing cjdroute..."
+    echo
+    killall cjdroute
+fi
 
-# Set permissions for cjdns-related-files
-chmod 755 /system/bin/cjd*
-chmod 755 /system/etc/init.d/99cjdroute
+# The uninstall functionality and a catch for invalid arguments
+if [ -n "$1" ]; then
+    if [ "$1" = "-u" -o "$1" = "--uninstall" ]; then
+        # Remount the system partition read/write
+        _sysrw
 
-# Remount /system read-only
-mount -o ro,remount $SYSTEM /system
+        echo "Removing cjdroid files from the ${SYSDISK} partition..."
+
+        # Remove cjdaemon
+        if [ -f "$BINDIR"/cjdaemon ]; then
+            rm "$BINDIR"/cjdaemon
+        else
+            echo " Warning: ${BINDIR}/cjdaemon is not present to be removed"
+        fi
+
+        # Remove cjdctl
+        if [ -f "$BINDIR"/cjdctl ]; then
+            rm "$BINDIR"/cjdctl
+        else
+            echo " Warning: ${BINDIR}/cjdctl is not present to be removed"
+        fi
+
+        # Remove cjdroute
+        if [ -f "$BINDIR"/cjdroute ]; then
+            rm "$BINDIR"/cjdroute
+        else
+            echo " Warning: ${BINDIR}/cjdroute is not present to be removed"
+        fi
+
+        # Remove 99cjdroute
+        if [ -f "$INITDIR"/99cjdroute ]; then
+            rm "$INITDIR"/99cjdroute
+        else
+            echo " Warning: ${INITDIR}/99cjdroute is not present to be removed"
+        fi
+
+        # Remount the system partition read-only
+        _sysro
+
+        # Exit successfully if all the cjdroid files are gone, otherwise complain
+        if [ ! -f "$BINDIR"/cjdaemon -a ! -f "$BINDIR"/cjdctl -a ! -f "$BINDIR"/cjdroute -a ! -f "$INITDIR"/99cjdroute ]; then
+            echo
+            echo "Uninstallation successfully completed!"
+            echo
+            exit 0
+        else
+            echo "Error: not all files were removed"
+            echo
+            exit 1
+        fi
+    else
+        echo
+        echo "Error: ${1} is not a valid argument"
+        echo
+        exit 1
+    fi
+fi
+
+# Remount the system partition read/write
+_sysrw
+
+# Copy cjdns-related-files to $SYSDISK
+echo
+echo "Copying files to the ${SYSDISK} partition..."
+if [ ! -f "files/cjdaemon" -o ! -f "files/cjdctl" -o ! -f "files/cjdroute" -o ! -f "files/99cjdroute" ]; then
+    echo "Error: one or more of the required files in 'files/' are missing"
+    echo
+    exit 1
+fi
+install -D -m755 files/cjdaemon "$BINDIR"/cjdaemon
+install -D -m755 files/cjdctl "$BINDIR"/cjdctl
+install -D -m755 files/cjdroute "$BINDIR"/cjdroute
+install -D -m755 files/99cjdroute "$INITDIR"/99cjdroute
+
+# Remount the system partition read-only
+_sysro
+
+# Exit successfully if all the files are where they should be, otherwise complain
+if [ -f "$BINDIR"/cjdaemon -a -f "$BINDIR"/cjdctl -a -f "$BINDIR"/cjdroute -a -f "$INITDIR"/99cjdroute ]; then
+    # Create the config directory if it doesn't already exist
+    if [ ! -d "$CJDPATH" ]; then
+        echo
+        echo "Creating cjdns config folder @ ${CJDPATH}..."
+        echo
+        install -d "$CJDPATH"
+    fi
+
+    # Generate a config file if the user doesn't already have one
+    if [ ! -f "$CJDPATH"/cjdroute.conf ]; then
+        echo
+        echo "Creating cjdns config file @ ${CJDPATH}/cjdroute.conf..."
+        echo
+        /system/bin/cjdroute --genconf > "$CJDPATH"/cjdroute.conf
+    fi
+
+    echo
+    echo "Installation successfully completed!"
+    echo " Ensure ${CJDPATH}/cjdroute.conf is configured then"
+    echo " run 'cjdctl enable' to start the cjdroute service"
+    echo
+    exit 0
+else
+    echo "Error: not all files were successfully copied"
+    echo
+    echo " Hint: Try rebooting then re-running this script"
+    echo
+    exit 1
+fi


### PR DESCRIPTION
I went through and tried to replace any more up to date method of doing things with more compatible, traditional methods, in case this might be a factor in some of the older phones not working. I also pulled a bunch of additional static statements and change them into more easily configured, dynamic values using variables, and attempted to refactor he code a bit for improved readability. Nothing so far should have altered the functional behaviour of the setup.

The changes that did affect behaviour include:
- Way more error-handling in `install.sh`, as well as better parsing (so fewer bizarre scenarios should produce errors)
- A **help** menu has been added to `install.sh`
- An **uninstall** feature has been added to `install.sh`, which removes the files the same files as were placed in _/system_ by the install
- The install and uninstall features in `install.sh` now both kill `cjdroute` before running, as android doesn't let you update or remove it when it's being used
- More feedback is given to explain what's happening behind the scenes, and in some cases, what the user should be doing next
- The `cjdctl` script now has a **restart** feature, in addition to its **enable** and **disable** features

There might be one or two other small things I'm not thinking of, but that should be all the big stuff. I've tested a bunch of scenarios and have had it running on my phone for a couple hours now (cjdroute getting auto-started/stopped by the daemon frequently as I lock/unlock my phone), and it's been working exactly like it should; that said, other testers are always welcome _ahem_ :).

Cheers
