### PR TITLE
Clairify that the admin interface is a UDP socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,9 +461,10 @@ stay on [IRC](#community) so that people can reach you.
 ## Admin interface
 
 When cjdnroute is up and running, the admin interface will be available at
-`localhost:11234` (this can be changed in the cjdroute.conf
+`udp://localhost:11234` (this can be changed in the cjdroute.conf
 configuration file). See [admin/README.md](admin/README.md) for more
-information about the admin interface.
+information about the admin interface. There are several tools in `contrib/`
+that can interact with it.
 
 You can access the admin API with:
 
@@ -489,4 +490,3 @@ You can access the admin API with:
 [Tor]: https://www.torproject.org
 [I2P]: http://www.i2p2.de
 [Freenet]: https://freenetproject.org
-


### PR DESCRIPTION
Several people seem to be under the impression that their cjdns isn't working because their browser won't load http://127.0.0.1:11234 - so I'm trying to clairify a bit. I feel like this might help, but I don't really know.
