### PR TITLE
Set return type in `main` to remove OS X warnings

### DIFF
--- a/node_build/dependencies/cnacl/tests/auth.c
+++ b/node_build/dependencies/cnacl/tests/auth.c
@@ -7,7 +7,7 @@ unsigned char c[28] = "what do ya want for nothing?";
 
 unsigned char a[32];
 
-main()
+int main()
 {
   int i;
   crypto_auth_hmacsha512256(a,c,sizeof c,key);

--- a/node_build/dependencies/cnacl/tests/auth2.c
+++ b/node_build/dependencies/cnacl/tests/auth2.c
@@ -22,7 +22,7 @@ unsigned char c[50] = {
 
 unsigned char a[32];
 
-main()
+int main()
 {
   int i;
   crypto_auth_hmacsha256(a,c,sizeof c,key);

--- a/node_build/dependencies/cnacl/tests/auth3.c
+++ b/node_build/dependencies/cnacl/tests/auth3.c
@@ -27,7 +27,7 @@ unsigned char a[32] = {
 ,0x7b,0xb1,0x56,0xd3,0xd7,0xb3,0x0d,0x3f
 } ;
 
-main()
+int main()
 {
   printf("%d\n",crypto_auth_hmacsha256_verify(a,c,sizeof c,key));
   return 0;

--- a/node_build/dependencies/cnacl/tests/auth5.c
+++ b/node_build/dependencies/cnacl/tests/auth5.c
@@ -7,7 +7,7 @@ unsigned char key[32];
 unsigned char c[10000];
 unsigned char a[32];
 
-main()
+int main()
 {
   int clen;
   int i;

--- a/node_build/dependencies/cnacl/tests/box.c
+++ b/node_build/dependencies/cnacl/tests/box.c
@@ -48,7 +48,7 @@ unsigned char m[163] = {
 
 unsigned char c[163];
 
-main()
+int main()
 {
   int i;
   crypto_box_curve25519xsalsa20poly1305(

--- a/node_build/dependencies/cnacl/tests/box2.c
+++ b/node_build/dependencies/cnacl/tests/box2.c
@@ -48,7 +48,7 @@ unsigned char c[163] = {
 
 unsigned char m[163];
 
-main()
+int main()
 {
   int i;
   if (crypto_box_curve25519xsalsa20poly1305_open(

--- a/node_build/dependencies/cnacl/tests/box7.c
+++ b/node_build/dependencies/cnacl/tests/box7.c
@@ -11,7 +11,7 @@ unsigned char m[10000];
 unsigned char c[10000];
 unsigned char m2[10000];
 
-main()
+int main()
 {
   int mlen;
   int i;

--- a/node_build/dependencies/cnacl/tests/box8.c
+++ b/node_build/dependencies/cnacl/tests/box8.c
@@ -12,7 +12,7 @@ unsigned char m[10000];
 unsigned char c[10000];
 unsigned char m2[10000];
 
-main()
+int main()
 {
   int mlen;
   int i;

--- a/node_build/dependencies/cnacl/tests/core1.c
+++ b/node_build/dependencies/cnacl/tests/core1.c
@@ -17,7 +17,7 @@ unsigned char c[16] = {
 
 unsigned char firstkey[32];
 
-main()
+int main()
 {
   int i;
   crypto_core_hsalsa20(firstkey,zero,shared,c);

--- a/node_build/dependencies/cnacl/tests/core2.c
+++ b/node_build/dependencies/cnacl/tests/core2.c
@@ -20,7 +20,7 @@ unsigned char c[16] = {
 
 unsigned char secondkey[32];
 
-main()
+int main()
 {
   int i;
   crypto_core_hsalsa20(secondkey,nonceprefix,firstkey,c);

--- a/node_build/dependencies/cnacl/tests/core3.c
+++ b/node_build/dependencies/cnacl/tests/core3.c
@@ -24,7 +24,7 @@ unsigned char output[64 * 256 * 256];
 
 unsigned char h[32];
 
-main()
+int main()
 {
   int i;
   long long pos = 0;

--- a/node_build/dependencies/cnacl/tests/core4.c
+++ b/node_build/dependencies/cnacl/tests/core4.c
@@ -20,7 +20,7 @@ unsigned char c[16] = {
 
 unsigned char out[64];
 
-main()
+int main()
 {
   int i;
   crypto_core_salsa20(out,in,k,c);

--- a/node_build/dependencies/cnacl/tests/core5.c
+++ b/node_build/dependencies/cnacl/tests/core5.c
@@ -20,7 +20,7 @@ unsigned char c[16] = {
 
 unsigned char out[32];
 
-main()
+int main()
 {
   int i;
   crypto_core_hsalsa20(out,in,k,c);

--- a/node_build/dependencies/cnacl/tests/core6.c
+++ b/node_build/dependencies/cnacl/tests/core6.c
@@ -32,7 +32,7 @@ void print(unsigned char *x,unsigned char *y)
   }
 }
 
-main()
+int main()
 {
   crypto_core_salsa20(out,in,k,c);
   print(out,c);

--- a/node_build/dependencies/cnacl/tests/onetimeauth.c
+++ b/node_build/dependencies/cnacl/tests/onetimeauth.c
@@ -30,7 +30,7 @@ unsigned char c[131] = {
 
 unsigned char a[16];
 
-main()
+int main()
 {
   int i;
   crypto_onetimeauth_poly1305(a,c,131,rs);

--- a/node_build/dependencies/cnacl/tests/onetimeauth2.c
+++ b/node_build/dependencies/cnacl/tests/onetimeauth2.c
@@ -33,7 +33,7 @@ unsigned char a[16] = {
 ,0x2a,0x7d,0xfb,0x4b,0x3d,0x33,0x05,0xd9
 } ;
 
-main()
+int main()
 {
   printf("%d\n",crypto_onetimeauth_poly1305_verify(a,c,131,rs));
   return 0;

--- a/node_build/dependencies/cnacl/tests/onetimeauth7.c
+++ b/node_build/dependencies/cnacl/tests/onetimeauth7.c
@@ -7,7 +7,7 @@ unsigned char key[32];
 unsigned char c[10000];
 unsigned char a[16];
 
-main()
+int main()
 {
   int clen;
   int i;

--- a/node_build/dependencies/cnacl/tests/scalarmult.c
+++ b/node_build/dependencies/cnacl/tests/scalarmult.c
@@ -10,7 +10,7 @@ unsigned char alicesk[32] = {
 
 unsigned char alicepk[32];
 
-main()
+int main()
 {
   int i;
   crypto_scalarmult_curve25519_base(alicepk,alicesk);

--- a/node_build/dependencies/cnacl/tests/scalarmult2.c
+++ b/node_build/dependencies/cnacl/tests/scalarmult2.c
@@ -10,7 +10,7 @@ unsigned char bobsk[32] = {
 
 unsigned char bobpk[32];
 
-main()
+int main()
 {
   int i;
   crypto_scalarmult_curve25519_base(bobpk,bobsk);

--- a/node_build/dependencies/cnacl/tests/scalarmult5.c
+++ b/node_build/dependencies/cnacl/tests/scalarmult5.c
@@ -17,7 +17,7 @@ unsigned char bobpk[32] = {
 
 unsigned char k[32];
 
-main()
+int main()
 {
   int i;
   crypto_scalarmult_curve25519(k,alicesk,bobpk);

--- a/node_build/dependencies/cnacl/tests/scalarmult6.c
+++ b/node_build/dependencies/cnacl/tests/scalarmult6.c
@@ -17,7 +17,7 @@ unsigned char alicepk[32] = {
 
 unsigned char k[32];
 
-main()
+int main()
 {
   int i;
   crypto_scalarmult_curve25519(k,bobsk,alicepk);

--- a/node_build/dependencies/cnacl/tests/secretbox.c
+++ b/node_build/dependencies/cnacl/tests/secretbox.c
@@ -41,7 +41,7 @@ unsigned char m[163] = {
 
 unsigned char c[163];
 
-main()
+int main()
 {
   int i;
   crypto_secretbox_xsalsa20poly1305(

--- a/node_build/dependencies/cnacl/tests/secretbox2.c
+++ b/node_build/dependencies/cnacl/tests/secretbox2.c
@@ -41,7 +41,7 @@ unsigned char c[163] = {
 
 unsigned char m[163];
 
-main()
+int main()
 {
   int i;
   if (crypto_secretbox_xsalsa20poly1305_open(

--- a/node_build/dependencies/cnacl/tests/secretbox7.c
+++ b/node_build/dependencies/cnacl/tests/secretbox7.c
@@ -8,7 +8,7 @@ unsigned char m[10000];
 unsigned char c[10000];
 unsigned char m2[10000];
 
-main()
+int main()
 {
   int mlen;
   int i;

--- a/node_build/dependencies/cnacl/tests/secretbox8.c
+++ b/node_build/dependencies/cnacl/tests/secretbox8.c
@@ -9,7 +9,7 @@ unsigned char m[10000];
 unsigned char c[10000];
 unsigned char m2[10000];
 
-main()
+int main()
 {
   int mlen;
   int i;

--- a/node_build/dependencies/cnacl/tests/stream.c
+++ b/node_build/dependencies/cnacl/tests/stream.c
@@ -19,7 +19,7 @@ unsigned char output[4194304];
 
 unsigned char h[32];
 
-main()
+int main()
 {
   int i;
   crypto_stream_xsalsa20(output,4194304,nonce,firstkey);

--- a/node_build/dependencies/cnacl/tests/stream2.c
+++ b/node_build/dependencies/cnacl/tests/stream2.c
@@ -17,7 +17,7 @@ unsigned char output[4194304];
 
 unsigned char h[32];
 
-main()
+int main()
 {
   int i;
   crypto_stream_salsa20(output,4194304,noncesuffix,secondkey);

--- a/node_build/dependencies/cnacl/tests/stream3.c
+++ b/node_build/dependencies/cnacl/tests/stream3.c
@@ -16,7 +16,7 @@ unsigned char nonce[24] = {
 
 unsigned char rs[32];
 
-main()
+int main()
 {
   int i;
   crypto_stream_xsalsa20(rs,32,nonce,firstkey);

--- a/node_build/dependencies/cnacl/tests/stream4.c
+++ b/node_build/dependencies/cnacl/tests/stream4.c
@@ -40,7 +40,7 @@ unsigned char m[163] = {
 
 unsigned char c[163];
 
-main()
+int main()
 {
   int i;
   crypto_stream_xsalsa20_xor(c,m,163,nonce,firstkey);


### PR DESCRIPTION
This patch fixes all these OS X warnings when compiling cjdns:

``` bash
warning: type specifier missing, defaults to 'int' [-Wimplicit-int]
```
