### PR TITLE
Restart on failure as well as "success", since cjdns shouldn't stop

### DIFF
--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/bin/sh -c "cjdroute --nobg < /etc/cjdroute.conf"
-Restart=on-failure
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
CJDNS has stopped on it's own twice in the past couple of months, and the connection stayed down until I restarted it manually both times, despite having systemd watching the process, because the failure causes it to finish with a **successful** exit status. Considering CJDNS shouldn't be stopping without instruction to do so either way, I thought it was appropriate to modify the systemd service so that it will restart cjdns whenever it stops, regardless of the exit status.

Cheers!
