### PR TITLE
OS X >= 10.10 ignores `-pie`, needs `-Wl,-pie` instead.

### DIFF
--- a/node_build/make.js
+++ b/node_build/make.js
@@ -91,9 +91,15 @@ Builder.configure({
         && builder.config.systemName !== 'win32')
     {
         builder.config.cflags.push('-fPIE');
+
         // just using `-pie` on OS X >= 10.10 results in this warning:
         // clang: warning: argument unused during compilation: '-pie'
-        builder.config.ldflags.push('-Wl,-pie');
+        if (builder.config.systemName !== "darwin")
+        {
+            builder.config.ldflags.push('-pie');
+        } else {
+            builder.config.ldflags.push('-Wl,-pie');
+        }
     }
 
     if (/clang/i.test(builder.config.gcc) || builder.config.systemName === 'darwin') {


### PR DESCRIPTION
The other day I compiled again and got a fun warning:

``` bash
clang: warning: argument unused during compilation: '-pie'
```

although it still compiled _properly_ and runs. After doing some searching I saw that you should use `-Wl,<option>` instead. I haven't tested this on 10.9 or lower, as I'm running 10.10. I'm not sure what versions of OS X cjdns supports, although I _don't think_ this would be a breaking change on <= 10.9.
