### PR TITLE
Fix bug in node time update

### DIFF
--- a/dht/dhtcore/RouterModule.c
+++ b/dht/dhtcore/RouterModule.c
@@ -516,8 +516,10 @@ static void onResponseOrTimeout(String* data, uint32_t milliseconds, void* vping
         return;
     }
 
-    // Update ping time of the node.
-    node->timeOfLastPing = Time_currentTimeMilliseconds(module->eventBase);
+    // Update ping time of the node if it came from the best path.
+    if (node->address.path == message->address->path) {
+        node->timeOfLastPing = Time_currentTimeMilliseconds(module->eventBase);
+    }
 
     #ifdef Log_DEBUG
         String* versionBin = Dict_getString(message->asDict, CJDHTConstants_VERSION);


### PR DESCRIPTION
Now it actually check that the path to the node is the one a message came in on before updating the time. Kind of important to remember...
