### PR TITLE
Print instructions for creating .cjdnsadmin to stderr, not stdout.

### DIFF
--- a/contrib/python/cjdnsadmin/cjdnsadmin.py
+++ b/contrib/python/cjdnsadmin/cjdnsadmin.py
@@ -258,15 +258,16 @@ def connectWithAdminInfo(path = None):
         with open(path, 'r') as adminInfo:
             data = json.load(adminInfo)
     except IOError:
-        print('Please create a file named .cjdnsadmin in your ')
-        print('home directory with')
-        print('ip, port, and password of your cjdns engine in json.')
-        print('for example:')
-        print('{')
-        print('    "addr": "127.0.0.1",')
-        print('    "port": 11234,')
-        print('    "password": "You tell me! (Search in ~/cjdroute.conf)"')
-        print('}')
+        sys.stderr.write("""Please create a file named .cjdnsadmin in your
+home directory with
+ip, port, and password of your cjdns engine in json.
+for example:
+{
+    "addr": "127.0.0.1",
+    "port": 11234,
+    "password": "You tell me! (Search in ~/cjdroute.conf)"
+}
+""")
         raise
 
     return connect(data['addr'], data['port'], data['password'])


### PR DESCRIPTION
Error messages belong on stderr, not stdout.  This bit me when I tried the following example from admin/README.md before I knew about ~/.cjdnsadmin:

    ./contrib/python/cexec 'functions()' | sort

The .cjdnsadmin file has to exist for this to work.  The file is not mentioned in README.  Without the file, the command fails and prints out instructions how to create .cjdnsadmin, but the sort command jumbles the instructions.  Not so if they are on stderr, where they belong.

I switched from Python's `print` to `sys.stderr.write` because there is no way to use `print` on stderr portably across all Python versions.  I switched from multiple print statements to one big string to avoid lots of \n in the code, personal preference.