### PR TITLE
included util/platform/Sockadr.h on FreeBSD

### DIFF
--- a/util/platform/netdev/NetPlatform_freebsd.c
+++ b/util/platform/netdev/NetPlatform_freebsd.c
@@ -16,6 +16,7 @@
 #include "exception/Except.h"
 #include "interface/Interface.h"
 #include "util/AddrTools.h"
+#include "util/platform/Sockaddr.h"
 
 #include <errno.h>
 #include <ctype.h>


### PR DESCRIPTION
Allows it to compile on FreeBSD.