### PR TITLE
Missing include for SockAddr in darwin NetPlatform

### DIFF
--- a/util/platform/netdev/NetPlatform_darwin.c
+++ b/util/platform/netdev/NetPlatform_darwin.c
@@ -15,6 +15,7 @@
 #include "exception/Except.h"
 #include "util/platform/netdev/NetPlatform.h"
 #include "util/AddrTools.h"
+#include "util/platform/Sockaddr.h"
 
 #include <errno.h>
 #include <stdio.h>


### PR DESCRIPTION
This bug was created by commit 57064d14f4cc27022b056de01345f53fbb761b39 , 
`NetPlatform_darwin.c` relayed on `AddrTools.h` to include `Sockaddr.h`