### PR TITLE
Refactor 'do' with more compliant bash that relies less on external commands

### DIFF
--- a/do
+++ b/do
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # You may redistribute this program and/or modify it under the terms of
 # the GNU General Public License as published by the Free Software Foundation,
 # either version 3 of the License, or (at your option) any later version.
@@ -10,13 +11,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 
-[ -n "$PLATFORM" ] || PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
-[ -n "$MARCH" ] || MARCH=$(uname -m | sed "s/i./x/g")
-BUILDDIR="build_${PLATFORM}"
-NODE_MIN_VER="v0.8.15"
+[[ -n "$PLATFORM" ]] \
+    || PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
 
-read -d '' VERSION_TEST <<"EOF"
+[[ -n "$MARCH" ]] \
+    || MARCH=$(uname -m | sed 's/i./x/g')
+
+build_dir="build_$PLATFORM"
+node_min_ver='v0.8.15'
+node_dl_ver='v0.10.24'
+
+read -d '' version_test <<"EOF"
 var currentVersion = process.version;
 var verArray = currentVersion.substring(1).split(".");
 var minVerArray = process.argv[process.argv.length-1].substring(1).split(".");
@@ -29,97 +36,136 @@ for (var i = 0; i < minVerArray.length; i++) {
 }
 EOF
 
-hasOkNode()
-{
-    for NODE in "$(pwd)/${BUILDDIR}/nodejs/node/bin/node" "nodejs" "node"; do
-        if ${NODE} -v >/dev/null 2>&1; then
-            echo ${VERSION_TEST} | ${NODE} '' ${NODE_MIN_VER} && return 0;
-            echo "You have a version of node [${NODE}] but it is too old [`${NODE} -v`]"
+# return true if the input command exists in $PATH
+function cmd_exists() {
+    type -P "$1" >/dev/null
+}
+
+# output an error and exit with a failed status
+function die() {
+    printf '%s\n' "ERROR: $1" >&2
+    exit 1
+}
+
+# detect and configure a copy of node.js to use with at least the minimum version
+function check_node_tool() {
+    for node_tool in "$build_dir/nodejs/node/bin/node" 'nodejs' 'node'; do
+        cmd_exists "$node_tool"
+        if [ $? = 0 -o -f "$node_tool" ]; then
+            "$node_tool" '' "$node_min_ver" <<< "$version_test" && {
+                node_cmd="$node_tool"
+                return 0
+            }
+            printf '%s\n' "You have a version of node [$node_tool] but it is too old [$($node_tool -v)]"
         fi
     done
     return 1
 }
 
-getNode()
-{
-    echo "Installing node.js"
-    echo "You can bypass this step by manually installing node.js ${NODE_MIN_VER} or newer"
-    if [ "${PLATFORM}-${MARCH}" = "linux-x86_64" ]; then
-        NODE_DOWNLOAD="http://nodejs.org/dist/v0.10.24/node-v0.10.24-linux-x64.tar.gz"
-        NODE_SHA="6ef93f4a5b53cdd4471786dfc488ba9977cb3944285ed233f70c508b50f0cb5f"
-    elif [ "${PLATFORM}-${MARCH}" = "linux-x86" ]; then
-        NODE_DOWNLOAD="http://nodejs.org/dist/v0.10.24/node-v0.10.24-linux-x86.tar.gz"
-        NODE_SHA="fb6487e72d953451d55e28319c446151c1812ed21919168b82ab1664088ecf46"
-    elif [ "${PLATFORM}-${MARCH}" = "linux-armv6l" ] || [ "${PLATFORM}-${MARCH}" = "linux-armv7l" ]; then #Raspberry Pi or Cubieboard
-        NODE_DOWNLOAD="http://nodejs.org/dist/v0.10.24/node-v0.10.24-linux-arm-pi.tar.gz"
-        NODE_SHA="bdd5e253132c363492fa24ed9985873733a10558240fd45b0a4a15989ab8da90"
-    elif [ "${PLATFORM}-${MARCH}" = "darwin-x86_64" ]; then
-        NODE_DOWNLOAD="http://nodejs.org/dist/v0.10.24/node-v0.10.24-darwin-x64.tar.gz"
-        NODE_SHA="c1c523014124a0327d71ba5d6f737a4c866a170f1749f8895482c5fa8be877b0"
-    elif [ "${PLATFORM}-${MARCH}" = "darwin-x86" ]; then
-        NODE_DOWNLOAD="http://nodejs.org/dist/v0.10.24/node-v0.10.24-darwin-x86.tar.gz"
-        NODE_SHA="8b8d2bf9828804c3f8027d7d442713318814a36df12dea97dceda8f4aff42b3c"
-    elif [ "${PLATFORM}-${MARCH}" = "sunos-x86_64" ]; then
-        NODE_DOWNLOAD="http://nodejs.org/dist/v0.10.24/node-v0.10.24-sunos-x64.tar.gz"
-        NODE_SHA="7cb714df92055b93a908b3b6587ca388a2884b1a9b5247c708a867516994a373"
-    elif [ "${PLATFORM}-${MARCH}" = "sunos-x86" ]; then
-        NODE_DOWNLOAD="http://nodejs.org/dist/v0.10.24/node-v0.10.24-sunos-x86.tar.gz"
-        NODE_SHA="af69ab26aae42b05841c098f5d11d17e21d22d980cd32666e2db45a53ddffe34"
-    else
-        echo "No nodejs executable available for ${PLATFORM}-${MARCH}"
-        echo -n "Please install nodejs (>= ${NODE_MIN_VER}) from "
-        echo "your distribution package repository or from source."
-        return 1
-    fi
-
-    origDir="$(pwd)"
-    [ -d "${BUILDDIR}/nodejs" ] && rm -r "${BUILDDIR}/nodejs"
-    mkdir -p "${BUILDDIR}/nodejs"
-    cd "${BUILDDIR}/nodejs"
-
-    if wget --version > /dev/null 2>&1; then
-        wget -O - "${NODE_DOWNLOAD}" > node.tar.gz
-    elif curl --version > /dev/null 2>&1; then
-        curl "${NODE_DOWNLOAD}" > node.tar.gz
-    else
-        echo 'wget or curl is required download node.js but you have neither!'
-        return 1
-    fi
-
-    if ! ( ${SHA256SUM} node.tar.gz | grep -q ${NODE_SHA} ); then
-        echo 'The downloaded file is damaged! Aborting.'
-        return 1
-    fi
-    tar -xzf node.tar.gz
-    find ./ -mindepth 1 -maxdepth 1 -type d -exec mv {} node \;
-    cd "$origDir"
-    hasOkNode && return 0;
-    return 1;
-}
-
-die() {
-    echo "ERROR: $1" >&2
-    exit 1
-}
-
-# get a sha256sum implementation.
-getsha256sum() {
-    expected="01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
-    for hasher in sha256sum gsha256sum sha256 'shasum -a 256' 'openssl sha256'
-    do
-        #echo "trying ${hasher} ${testFile}"
-        echo '' | ${hasher} - 2>/dev/null | grep -q ${expected} && SHA256SUM=${hasher} && return 0
+# detect and configure a sha256sum implementation to use that produces the expected sum for an empty string
+function get_shasum_tool() {
+    expected_sum='01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b'
+    for shasum_tool in 'sha256sum' 'gsha256sum' 'sha256' 'shasum -a 256' 'openssl sha256'; do
+        if cmd_exists "${shasum_tool/ *}"; then
+            [[ $($shasum_tool <<< '') =~ "$expected_sum" ]] && {
+                shasum_cmd="$shasum_tool"
+                return 0
+            }
+        fi
     done
     return 1
 }
 
-main() {
-    cd "$(dirname $0)" || die "failed to set directory"
-    [ -d "${BUILDDIR}" ] || mkdir "${BUILDDIR}" || die "failed to create build dir ${BUILDDIR}"
-    getsha256sum || die "couldn't find working sha256 hasher";
-    hasOkNode || getNode || die "could not get working nodejs impl";
+# download and configure a copy of node.js to use based on the current system
+function get_node_tool() {
+    printf '%s %s\n\n' '###' "Installing node.js (you can bypass this step by manually installing node.js $node_min_ver or newer)"
+    case "$PLATFORM-$MARCH" in
+        linux-x86_64)
+            node_download="http://nodejs.org/dist/$node_dl_ver/node-$node_dl_ver-linux-x64.tar.gz"
+            node_sha='6ef93f4a5b53cdd4471786dfc488ba9977cb3944285ed233f70c508b50f0cb5f'
+            ;;
+        linux-x86)
+            node_download="http://nodejs.org/dist/$node_dl_ver/node-$node_dl_ver-linux-x86.tar.gz"
+            node_sha='fb6487e72d953451d55e28319c446151c1812ed21919168b82ab1664088ecf46'
+            ;;
+        linux-armv6l|linux-armv7l)
+            # Raspberry Pi or Cubieboard
+            node_download="http://nodejs.org/dist/$node_dl_ver/node-$node_dl_ver-linux-arm-pi.tar.gz"
+            node_sha='bdd5e253132c363492fa24ed9985873733a10558240fd45b0a4a15989ab8da90'
+            ;;
+        darwin-x86_64)
+            node_download="http://nodejs.org/dist/$node_dl_ver/node-$node_dl_ver-darwin-x64.tar.gz"
+            node_sha='c1c523014124a0327d71ba5d6f737a4c866a170f1749f8895482c5fa8be877b0'
+            ;;
+        darwin-x86)
+            node_download="http://nodejs.org/dist/$node_dl_ver/node-$node_dl_ver-darwin-x86.tar.gz"
+            node_sha='8b8d2bf9828804c3f8027d7d442713318814a36df12dea97dceda8f4aff42b3c'
+            ;;
+        sunos-x86_64)
+            node_download="http://nodejs.org/dist/$node_dl_ver/node-$node_dl_ver-sunos-x64.tar.gz"
+            node_sha='7cb714df92055b93a908b3b6587ca388a2884b1a9b5247c708a867516994a373'
+            ;;
+        sunos-x86)
+            node_download="http://nodejs.org/dist/$node_dl_ver/node-$node_dl_ver-sunos-x86.tar.gz"
+            node_sha='af69ab26aae42b05841c098f5d11d17e21d22d980cd32666e2db45a53ddffe34'
+            ;;
+        *)
+            printf '%s\n%s\n' \
+                "No nodejs executable available for $PLATFORM-$MARCH" \
+                "Please install nodejs (>= $node_min_ver) from your distribution package repository or from source"
+            return 1
+            ;;
+    esac
 
-    $NODE ./node_build/make.js "${@}" || return 1
+    [[ -d "$build_dir/nodejs" ]] \
+        && rm -r "$build_dir/nodejs"
+    install -d "$build_dir/nodejs"
+
+    pushd "$build_dir/nodejs" >/dev/null
+    node_dl="node-${node_dl_ver}.tar.gz"
+    if cmd_exists wget; then
+        printf '\n%s %s ' '==>' "Downloading $node_download with wget..."
+        wget -q "$node_download" -O "$node_dl"
+    elif cmd_exists curl; then
+        printf '%s %s ' '==>' "Downloading $node_download with curl..."
+        curl -s "$node_download" > "$node_dl"
+    else
+        die 'wget or curl is required download node.js but you have neither!'
+    fi
+    [[ -f "$node_dl" ]] \
+        || die 'Failed to download node.js'
+    printf '%s\n' 'DONE!'
+
+    printf '%s %s ' '==>' "Verifying the checksum of the downloaded archive..."
+    [[ $($shasum_cmd "$node_dl") =~ $node_sha ]] \
+        || die 'The downloaded file is damaged! Aborting'
+    printf '%s\n' 'DONE!'
+
+    printf '%s %s ' '==>' "Extracting the downloaded archive..."
+    install -d node
+    tar xzf "$node_dl" -C node --strip-components=1
+    [[ -d 'node' ]] \
+        || die 'An error prevented the archive from being extracted'
+    printf '%s\n\n' 'DONE!'
+    popd >/dev/null
+
+    # Return with the success status of the check_node_tool function
+    check_node_tool
 }
 
-main
+cd "$(dirname $0)" \
+    || die 'failed to set directory'
+
+[[ -d "$build_dir" ]] \
+    || install -d "$build_dir" \
+        || die "failed to create build dir $build_dir"
+
+get_shasum_tool \
+    || die "couldn't find working sha256 shasum_tool";
+
+check_node_tool \
+    || get_node_tool \
+        || die "couldn't get working node.js implementation";
+
+"$node_cmd" ./node_build/make.js "$@"
+


### PR DESCRIPTION
The output of the node download/install is a bit more verbose than before, but the rest should pretty well all be background changes.

Some of the more noteworthy changes include:
* The downloaded node version is variable
* The massive if/else for `$PLATFORM-$MARCH` is now a case statement
* Variables are lower-case unless they can be set in the external environment (as per _best practices_)
* The `printf` command is used in place of `echo`
* A lot of functionality that relied on external commands has been replaced by equivalent functionality using built-ins
* Each function has a comment explaining its behaviour
* A lot of older ways to do things were updated to more up to date methods

All the changes should more or less mirror the original functionality, and I've tested builds both on boxes that required building **node.js** as well as ones that didn't (though in both cases they were **x86_64**).

Since this is an important file in the scheme of things, I should add that I won't feel bad if this request isn't pulled for one reason or another-- do what you gotta do!

Cheers