### PR TITLE
[node_build/make] if empty (but assigned) string, then no ssp_support

### DIFF
--- a/node_build/make.js
+++ b/node_build/make.js
@@ -154,6 +154,7 @@ Builder.configure({
         case 'y':
         case '1': libssp = true; break;
         case 'n':
+        case '' :
         case '0': libssp = false; break;
         case undefined: break;
         default: throw new Error();


### PR DESCRIPTION
typeof SSP_SUPPORT = string (SSP_SUPPORT="" ./do)
typoeof SSP_SUPPORT = undefined (./do)
should fix xcompiling in openwrt land