### PR TITLE
Adding NO_MARCH_FLAG for unsupported architectures

### DIFF
--- a/node_build/make.js
+++ b/node_build/make.js
@@ -29,6 +29,8 @@ var GCC = process.env['CC'];
 var CFLAGS = process.env['CFLAGS'];
 var LDFLAGS = process.env['LDFLAGS'];
 
+var NO_MARCH_FLAG = ['ppc', 'ppc64'];
+
 if (!GCC) {
     if (SYSTEM === 'freebsd') {
         GCC = 'gcc47';
@@ -78,7 +80,11 @@ Builder.configure({
         builder.config.cflags.push('-D', 'TESTING=1');
     }
 
-    if (!builder.config.crossCompiling) { builder.config.cflags.push('-march=native'); }
+    if (!builder.config.crossCompiling) { 
+        if (NO_MARCH_FLAG.indexOf(process.arch) < -1) {
+            builder.config.cflags.push('-march=native');
+        }
+    }
 
     if (builder.config.systemName === 'win32') {
         builder.config.cflags.push('-Wno-format');
@@ -240,7 +246,11 @@ Builder.configure({
                     [].push.apply(args, CFLAGS.split(' '));
                 }
 
-                if (!builder.config.crossCompiling) { args.push('-march=native'); }
+                if (!builder.config.crossCompiling) { 
+                    if (NO_MARCH_FLAG.indexOf(process.arch) < -1) {
+                        builder.config.cflags.push('-march=native');
+                    }
+                }
 
                 builder.cc(args, callback);
             }, waitFor(function () {


### PR DESCRIPTION
ppc64 gcc has issues with `--march=native` flag.

I'm working on getting `cjdns` working on PPC64 (again).

These changes get me pretty far in the build :D