### PR TITLE
Pathfinder.c, only discover paths that aren't already known.

### DIFF
--- a/dht/Pathfinder.c
+++ b/dht/Pathfinder.c
@@ -25,7 +25,6 @@
 #include "dht/dhtcore/RumorMill.h"
 #include "dht/dhtcore/SearchRunner.h"
 #include "dht/dhtcore/SearchRunner_admin.h"
-#include "dht/dhtcore/NodeStore.h"
 #include "dht/dhtcore/NodeStore_admin.h"
 #include "dht/dhtcore/Janitor.h"
 #include "dht/dhtcore/Router_new.h"

--- a/dht/Pathfinder.c
+++ b/dht/Pathfinder.c
@@ -25,6 +25,7 @@
 #include "dht/dhtcore/RumorMill.h"
 #include "dht/dhtcore/SearchRunner.h"
 #include "dht/dhtcore/SearchRunner_admin.h"
+#include "dht/dhtcore/NodeStore.h"
 #include "dht/dhtcore/NodeStore_admin.h"
 #include "dht/dhtcore/Janitor.h"
 #include "dht/dhtcore/Router_new.h"
@@ -341,9 +342,11 @@ static Iface_DEFUN discoveredPath(struct Message* msg, struct Pathfinder_pvt* pf
 {
     struct Address addr;
     addressForNode(&addr, msg);
-    String* str = Address_toString(&addr, msg->alloc);
-    Log_debug(pf->log, "Discovered path [%s]", str->bytes);
-    RumorMill_addNode(pf->rumorMill, &addr);
+    if (!NodeStore_linkForPath(pf->nodeStore, addr.path)) {
+        String* str = Address_toString(&addr, msg->alloc);
+        Log_debug(pf->log, "Discovered path [%s]", str->bytes);
+        RumorMill_addNode(pf->rumorMill, &addr);
+    }
     return NULL;
 }
 


### PR DESCRIPTION
Attempted fix for an issue where the janitor never does any useful work because the external rumormill is always filled with the same (already known) paths.

On my end, this does not appear to completely fix the issue. The external rumormill still sees a lot more churn than I would have expected, but it's at last not wasting time with already-known paths. Instead it (slowly) winds down to hover around empty, still using up more time than I would have expected, but allowing the janitor to occasionally do other things.