### PR TITLE
RouterModule.c : comment out the self ping assertion

### DIFF
--- a/dht/dhtcore/RouterModule.c
+++ b/dht/dhtcore/RouterModule.c
@@ -541,10 +541,6 @@ struct RouterModule_Promise* RouterModule_newMessage(struct Address* addr,
                                                      struct RouterModule* module,
                                                      struct Allocator* alloc)
 {
-    // sending yourself a ping?
-//    Assert_true(Bits_memcmp(addr->key, module->address.key, 32));
-    Assert_true(addr->path != 1);
-
     Assert_ifParanoid(addr->path ==
         EncodingScheme_convertLabel(module->nodeStore->selfNode->encodingScheme,
                                     addr->path,


### PR DESCRIPTION
...since that logic is now handled elsewhere and it was causing silly crashes.

## Relevant info

* [the comment in question](https://github.com/cjdelisle/cjdns/commit/581dac9dce1e8c6374f131164117ec52fce770f7#commitcomment-10749642)
* [the issue on the hyperboria/cjdns issue tracker](https://github.com/hyperboria/cjdns/issues/23)