### PR TITLE
Fixed Debian package for systemd-based Debian distros

### DIFF
--- a/debian/cjdns.service
+++ b/debian/cjdns.service
@@ -1,0 +1,1 @@
+../contrib/systemd/cjdns.service

--- a/debian/rules
+++ b/debian/rules
@@ -23,6 +23,3 @@ override_dh_strip:
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/cjdns
-
-override_dh_installinit:
-	dh_installinit --upstart-only


### PR DESCRIPTION
Makes it possible to use the Debian-build method (`dpkg-buildpackage`) on systemd-based Debian systems (such as Debian 8, Ubuntu 15.04, ...)

This µ-patch does not add support for legacy SysVInit under Debian!