### PR TITLE
Fix seccomp on ARM

### DIFF
--- a/util/Seccomp.c
+++ b/util/Seccomp.c
@@ -41,10 +41,23 @@
  */
 #define IS_WORKING_ERRNO 3333
 
+/**
+ * Accessing the SIGSYS siginfo depends on the fields being defined by the libc.
+ * Older libc do not yet include the needed definitions and accessor macros.
+ * Work around that by falling back to si_value.sival_int which works on some
+ * but not all architectures.
+ */
+#if defined(si_syscall)
+# define GET_SYSCALL_NUM(si) ((si)->si_syscall)
+#else
+# warning "your libc doesn't define SIGSYS signal info!"
+# define GET_SYSCALL_NUM(si) ((si)->si_value.sival_int)
+#endif
+
 static void catchViolation(int sig, siginfo_t* si, void* threadContext)
 {
     printf("Attempted banned syscall number [%d] see doc/Seccomp.md for more information\n",
-           si->si_value.sival_int);
+           GET_SYSCALL_NUM(si));
     Assert_failure("Disallowed Syscall");
 }
 

--- a/util/Seccomp.c
+++ b/util/Seccomp.c
@@ -219,6 +219,11 @@ static struct sock_fprog* mkFilter(struct Allocator* alloc, struct Except* eh)
             IFEQ(__NR_epoll_pwait, success),
         #endif
 
+        // gettimeofday is required on some architectures
+        #ifdef __NR_gettimeofday
+            IFEQ(__NR_gettimeofday, success),
+        #endif
+
         // TUN (and logging)
         IFEQ(__NR_write, success),
         IFEQ(__NR_read, success),


### PR DESCRIPTION
seccomp violation reporting was broken on ARM due to libc brokenness.
Fix this by defining a best-effort accessor macro working around outdated libc which miss the definitions to acquire the offending syscall number in a *portable* way.

Now that reporting seccomp filter violations worked again, it was easy to figure out that `gettimeofday` was missing in the list of allowed syscalls, so include it.