### PR TITLE
Adding glibc backtrace dump on assertion failed

### DIFF
--- a/node_build/make.js
+++ b/node_build/make.js
@@ -56,7 +56,6 @@ Builder.configure({
         '-Werror',
         '-Wno-pointer-sign',
         '-pedantic',
-        '-rdynamic',
         '-D', builder.config.systemName + '=1',
         '-Wno-unused-parameter',
         '-fomit-frame-pointer',

--- a/node_build/make.js
+++ b/node_build/make.js
@@ -56,6 +56,7 @@ Builder.configure({
         '-Werror',
         '-Wno-pointer-sign',
         '-pedantic',
+        '-rdynamic',
         '-D', builder.config.systemName + '=1',
         '-Wno-unused-parameter',
         '-fomit-frame-pointer',

--- a/util/Assert.c
+++ b/util/Assert.c
@@ -19,6 +19,10 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+#ifdef __GLIBC__
+#  include <execinfo.h>
+#endif
+
 Gcc_PRINTF(1, 2)
 void Assert_failure(const char* format, ...)
 {
@@ -29,6 +33,24 @@ void Assert_failure(const char* format, ...)
     va_start(args, format);
     vfprintf(stderr, format, args);
     fflush(stderr);
+
+#ifdef __GLIBC__
+    void *array[20];
+    size_t size;
+    char **strings;
+    size_t i;
+
+    size = backtrace (array, 20);
+    strings = backtrace_symbols (array, size);
+
+    fprintf(stderr, "Backtrace (%zd frames):\n", size);
+    for (i = 0; i < size; i++) {
+        fprintf(stderr, "  %s\n", strings[i]);
+    }
+    fflush(stderr);
+    free(strings);
+
+#endif
     abort();
     va_end(args);
 }

--- a/util/Assert.c
+++ b/util/Assert.c
@@ -36,15 +36,11 @@ void Assert_failure(const char* format, ...)
 
 #ifdef __GLIBC__
     void *array[20];
-    size_t size;
-    char **strings;
-    size_t i;
-
-    size = backtrace(array, 20);
-    strings = backtrace_symbols(array, size);
+    size_t size = backtrace(array, 20);
+    char **strings = backtrace_symbols(array, size);
 
     fprintf(stderr, "Backtrace (%zd frames):\n", size);
-    for (i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
     {
         fprintf(stderr, "  %s\n", strings[i]);
     }

--- a/util/Assert.c
+++ b/util/Assert.c
@@ -40,11 +40,12 @@ void Assert_failure(const char* format, ...)
     char **strings;
     size_t i;
 
-    size = backtrace (array, 20);
-    strings = backtrace_symbols (array, size);
+    size = backtrace(array, 20);
+    strings = backtrace_symbols(array, size);
 
     fprintf(stderr, "Backtrace (%zd frames):\n", size);
-    for (i = 0; i < size; i++) {
+    for (i = 0; i < size; i++)
+    {
         fprintf(stderr, "  %s\n", strings[i]);
     }
     fflush(stderr);


### PR DESCRIPTION
This produces a dump like this:
```
Assertion failure [Admin.c:182] [(0 && txid && txid->len >= admin->addrLen)]
Backtrace (11 frames):
  /home/viric/3rd/cjdns/cjdroute(+0x71f0) [0x7fbadaeeb1f0]
  /home/viric/3rd/cjdns/cjdroute(+0x10fca) [0x7fbadaef4fca]
  /home/viric/3rd/cjdns/cjdroute(+0x38b11) [0x7fbadaf1cb11]
  /home/viric/3rd/cjdns/cjdroute(+0x7a3f3) [0x7fbadaf5e3f3]
  /home/viric/3rd/cjdns/cjdroute(+0x7b567) [0x7fbadaf5f567]
  /home/viric/3rd/cjdns/cjdroute(+0x70997) [0x7fbadaf54997]
  /home/viric/3rd/cjdns/cjdroute(+0xc295) [0x7fbadaef0295]
  /home/viric/3rd/cjdns/cjdroute(+0x58d90) [0x7fbadaf3cd90]
  /home/viric/3rd/cjdns/cjdroute(main+0x314) [0x7fbadaee9de4]
  /nix/store/la5imi1602jxhpds9675n2n2d0683lbq-glibc-2.20/lib/libc.so.6(__libc_start_main+0xf5) [0x7fbada521c15]
  /home/viric/3rd/cjdns/cjdroute(+0x6c61) [0x7fbadaeeac61]
```

The addresses can be resolved with addr2line:
```
$ addr2line -e cjdroute 
0x71f0
/home/viric/3rd/cjdns/util/Assert.c:44
0x10fca
/home/viric/3rd/cjdns/./interface/Iface.h:61
0x38b11
/home/viric/3rd/cjdns/./interface/Iface.h:77
0x7a3f3
/home/viric/3rd/cjdns/build_linux/dependencies/libuv/out/../src/unix/udp.c:228
0x7b567
/home/viric/3rd/cjdns/build_linux/dependencies/libuv/out/../src/unix/linux-core.c:222
0x70997
/home/viric/3rd/cjdns/build_linux/dependencies/libuv/out/../src/unix/core.c:285
...
```

By the way, this assertion failure is fake, introduced just for testing. The backtrace dump should be enabled only on glibc systems. The usage of "-rdynamic" (see man gcc) in compilation allows for some resolutions of symbols (like main). On other programs I have tested it really provides function names properly.

If we wanted the filename and line in the backtrace output, it would be more complicated (linking libunwind, libbfd, ...).
```