### PR TITLE
seccomp: allow readv and writev syscalls (used by musl)

### DIFF
--- a/util/Seccomp.c
+++ b/util/Seccomp.c
@@ -240,6 +240,13 @@ static struct sock_fprog* mkFilter(struct Allocator* alloc, struct Except* eh)
         // TUN (and logging)
         IFEQ(__NR_write, success),
         IFEQ(__NR_read, success),
+        // readv and writev are used by some libc (musl)
+        #ifdef __NR_readv
+            IFEQ(__NR_readv, success),
+        #endif
+        #ifdef __NR_writev
+            IFEQ(__NR_writev, success),
+        #endif
 
         // modern librt reads a read-only mapped section of kernel space which contains the time
         // older versions need system calls for getting the time.


### PR DESCRIPTION
syscalls called by musl (here: on ARMv6 little endian) differ from those called when using uClibc on OpenWrt.
details (found using procd's 'utrace' tool):
```
--- cjdroute.28642.json	2015-05-20 01:42:11.808646316 +0200
+++ cjdroute.32494.json	2015-05-20 01:22:03.966987469 +0200
@@ -8,15 +9,13 @@
 		"unlink",
 		"brk",
 		"ioctl",
-		"gettimeofday",
 		"readlink",
 		"sigreturn",
-		"clone",
-		"_sysctl",
+		"readv",
+		"writev",
 		"rt_sigreturn",
 		"rt_sigaction",
 		"rt_sigprocmask",
-		"futex",
 		"exit_group",
 		"epoll_ctl",
 		"epoll_wait",
```