### PR TITLE
fix Hex_test unit test

### DIFF
--- a/util/test/Hex_test.c
+++ b/util/test/Hex_test.c
@@ -28,7 +28,7 @@ int main()
     uint8_t bytes[32];
     Random_bytes(rand, bytes, 32);
 
-    uint8_t hex[64] = {0};
+    uint8_t hex[65] = {0};
 
     Assert_true(Hex_encode(hex, 65, bytes, 32) == 64);
 


### PR DESCRIPTION
There was no space for the trailing '\0' in the array used to
store the hex string in Hex_test which resulted in a segfault.
Increasing the size of the array by one fixes that.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>