### PR TITLE
Allow building the Ubuntu package on Ubuntu 12.04

### DIFF
--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -7,7 +7,7 @@ After=network.target
 Type=simple
 ProtectHome=true
 ProtectSystem=true
-ExecPreStart=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; \
+ExecStartPre=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; \
                 then umask 077; \
                 /usr/bin/cjdroute --genconf > /etc/cjdroute.conf; \
                 echo 'WARNING: A new /etc/cjdroute.conf file has been generated.'; \

--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -5,6 +5,8 @@ After=network.target
 
 [Service]
 Type=simple
+ProtectHome=true
+ProtectSystem=true
 ExecStart=/bin/sh -c "cjdroute --nobg < /etc/cjdroute.conf"
 Restart=always
 

--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -7,10 +7,10 @@ After=network.target
 Type=simple
 ProtectHome=true
 ProtectSystem=true
-ExecPreStart=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; then
-                umask 077 # to create the file with 600 permissions without races
-                /usr/bin/cjdroute --genconf > /etc/cjdroute.conf
-                echo 'WARNING: A new /etc/cjdroute.conf file has been generated.'
+ExecPreStart=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; \
+                then umask 077; \
+                /usr/bin/cjdroute --genconf > /etc/cjdroute.conf; \
+                echo 'WARNING: A new /etc/cjdroute.conf file has been generated.'; \
             fi"
 ExecStart=/bin/sh -c "cjdroute --nobg < /etc/cjdroute.conf"
 Restart=always

--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -7,6 +7,11 @@ After=network.target
 Type=simple
 ProtectHome=true
 ProtectSystem=true
+ExecPreStart=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; then
+                umask 077 # to create the file with 600 permissions without races
+                /usr/bin/cjdroute --genconf > /etc/cjdroute.conf
+                echo 'WARNING: A new /etc/cjdroute.conf file has been generated.'
+            fi"
 ExecStart=/bin/sh -c "cjdroute --nobg < /etc/cjdroute.conf"
 Restart=always
 

--- a/debian/cjdns.service
+++ b/debian/cjdns.service
@@ -1,0 +1,1 @@
+../contrib/systemd/cjdns.service

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,10 @@
 Source: cjdns
 Section: comm
-Priority: extra
+Priority: optional
 Maintainer: Sergey "Shnatsel" Davidoff <shnatsel@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), nodejs (>= 0.8.15) | wget, python (>= 2.7)
-Standards-Version: 3.9.2
+Build-Depends: debhelper (>= 8.0.0), nodejs (>= 0.8.15) | wget, python (>= 2.7),
+               dh-systemd (>= 1.5)
+Standards-Version: 3.9.5
 Homepage: https://github.com/cjdelisle/cjdns/
 Vcs-Git: git://github.com/cjdelisle/cjdns.git
 Vcs-Browser: https://github.com/cjdelisle/cjdns/
@@ -35,6 +36,7 @@ Description: Encrypted networking for regular people (debugging symbols)
 
 Package: cjdns-dynamic
 Architecture: any
+Priority: extra
 Depends: cjdns (= ${binary:Version}), ${misc:Depends}, python (>= 2.7)
 Description: cjdns dynamic DNS peer resolver service
  This package contains a dynamic DNS peer resolver script that allows you to use

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: cjdns
 Section: comm
 Priority: extra
 Maintainer: Sergey "Shnatsel" Davidoff <shnatsel@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), nodejs (>= 0.8.15) | wget, python (>= 2.7), dh-python
+Build-Depends: debhelper (>= 8.0.0), nodejs (>= 0.8.15) | wget, python (>= 2.7)
 Standards-Version: 3.9.2
 Homepage: https://github.com/cjdelisle/cjdns/
 Vcs-Git: git://github.com/cjdelisle/cjdns.git
@@ -11,7 +11,7 @@ X-Python-Version: >= 2.7
 
 Package: cjdns
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.7)
 Suggests: cjdns-dynamic
 Description: Encrypted networking for regular people
  Cjdns implements an encrypted IPv6 network using public key cryptography

--- a/debian/rules
+++ b/debian/rules
@@ -10,7 +10,7 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ --with python2
+	dh $@ --with python2 --with systemd
 
 override_dh_auto_configure:
 	debian/do-wrapper


### PR DESCRIPTION
Drop dh-python build depdency. It was supposed to provide dynamic Python version dependency, but that did not work out (see commit 57db401db8faeb9db4cb182d431a661ebddc9ce3). 

In the current state the cjdns-dynamic binary package has no Python dependency at all, which is a bug. This change fixes that and allows building cjdns on Ubuntu 12.04 yet again.