### PR TITLE
Add systemd .service to debian package

### DIFF
--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -7,7 +7,7 @@ After=network.target
 Type=simple
 ProtectHome=true
 ProtectSystem=true
-ExecPreStart=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; \
+ExecStartPre=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; \
                 then umask 077; \
                 /usr/bin/cjdroute --genconf > /etc/cjdroute.conf; \
                 echo 'WARNING: A new /etc/cjdroute.conf file has been generated.'; \

--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -5,6 +5,8 @@ After=network.target
 
 [Service]
 Type=simple
+ProtectHome=true
+ProtectSystem=true
 ExecStart=/bin/sh -c "cjdroute --nobg < /etc/cjdroute.conf"
 Restart=always
 

--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -7,10 +7,10 @@ After=network.target
 Type=simple
 ProtectHome=true
 ProtectSystem=true
-ExecPreStart=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; then
-                umask 077 # to create the file with 600 permissions without races
-                /usr/bin/cjdroute --genconf > /etc/cjdroute.conf
-                echo 'WARNING: A new /etc/cjdroute.conf file has been generated.'
+ExecPreStart=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; \
+                then umask 077; \
+                /usr/bin/cjdroute --genconf > /etc/cjdroute.conf; \
+                echo 'WARNING: A new /etc/cjdroute.conf file has been generated.'; \
             fi"
 ExecStart=/bin/sh -c "cjdroute --nobg < /etc/cjdroute.conf"
 Restart=always

--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -7,6 +7,11 @@ After=network.target
 Type=simple
 ProtectHome=true
 ProtectSystem=true
+ExecPreStart=/bin/sh -ec "if ! test -e /etc/cjdroute.conf; then
+                umask 077 # to create the file with 600 permissions without races
+                /usr/bin/cjdroute --genconf > /etc/cjdroute.conf
+                echo 'WARNING: A new /etc/cjdroute.conf file has been generated.'
+            fi"
 ExecStart=/bin/sh -c "cjdroute --nobg < /etc/cjdroute.conf"
 Restart=always
 

--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=A routing engine designed for security, scalability, speed and ease of use
+Description=cjdns: routing engine designed for security, scalability, speed and ease of use
 Wants=network.target
 After=network.target
 

--- a/debian/README
+++ b/debian/README
@@ -1,7 +1,7 @@
 Ubuntu Packaging for cjdns
 ----------------------------
 
-This packaging is designed for use in daily builds and targets Ubuntu 12.04 and higher. 
+This packaging is designed for use in daily builds and targets Ubuntu 14.04 and higher.
 
 It provides three binary packages:
  * "cjdns" contains:
@@ -16,6 +16,7 @@ It provides three binary packages:
  * "cjdns-dbg":
    - Debugging symbols for cjdns, useful for reporting and investigating crashes.
 
-This packaging includes Ubuntu-specific items such as an Upstart script and will not work on Debian as-is.
+The package provides both Upstart and systemd configs and should, in theory,
+work on Debian Jessie. It was not tested.
 
  -- Sergey "Shnatsel" Davidoff <shnatsel@gmail.com>  Wed, 20 May 2015 12:57:10 +0300

--- a/debian/cjdns.service
+++ b/debian/cjdns.service
@@ -1,0 +1,1 @@
+../contrib/systemd/cjdns.service

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,10 @@
 Source: cjdns
 Section: comm
-Priority: extra
+Priority: optional
 Maintainer: Sergey "Shnatsel" Davidoff <shnatsel@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), nodejs (>= 0.8.15) | wget, python (>= 2.7)
-Standards-Version: 3.9.2
+Build-Depends: debhelper (>= 8.0.0), nodejs (>= 0.8.15) | wget, python (>= 2.7),
+               dh-systemd (>= 1.5)
+Standards-Version: 3.9.5
 Homepage: https://github.com/cjdelisle/cjdns/
 Vcs-Git: git://github.com/cjdelisle/cjdns.git
 Vcs-Browser: https://github.com/cjdelisle/cjdns/
@@ -35,6 +36,7 @@ Description: Encrypted networking for regular people (debugging symbols)
 
 Package: cjdns-dynamic
 Architecture: any
+Priority: extra
 Depends: cjdns (= ${binary:Version}), ${misc:Depends}, python (>= 2.7)
 Description: cjdns dynamic DNS peer resolver service
  This package contains a dynamic DNS peer resolver script that allows you to use

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: cjdns
 Section: comm
 Priority: extra
 Maintainer: Sergey "Shnatsel" Davidoff <shnatsel@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), nodejs (>= 0.8.15) | wget, python (>= 2.7), dh-python
+Build-Depends: debhelper (>= 8.0.0), nodejs (>= 0.8.15) | wget, python (>= 2.7)
 Standards-Version: 3.9.2
 Homepage: https://github.com/cjdelisle/cjdns/
 Vcs-Git: git://github.com/cjdelisle/cjdns.git
@@ -11,7 +11,7 @@ X-Python-Version: >= 2.7
 
 Package: cjdns
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.7)
 Suggests: cjdns-dynamic
 Description: Encrypted networking for regular people
  Cjdns implements an encrypted IPv6 network using public key cryptography

--- a/debian/rules
+++ b/debian/rules
@@ -10,7 +10,7 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ --with python2
+	dh $@ --with python2 --with systemd
 
 override_dh_auto_configure:
 	debian/do-wrapper


### PR DESCRIPTION
* Expand systemd .service with autogeneration of skeleton config if no config file exists in /etc/cjdroute.conf
* Add the systemd .service to Debian/Ubuntu package "cjdns".
* Update debian/README accordingly, other minor fixes

Ubuntu 12.04 ain't supported after all, but we should gain support for Ubuntu 15.04 and Debian Jessie instead.

This PR supersedes #775, #781, #782. No systemd .service exists for dynamic endpoints yet, that will come in another PR.