### PR TITLE
Update to latest android ndk to fix build issue for permissions 

### DIFF
--- a/contrib/android/cjdroid-build.sh
+++ b/contrib/android/cjdroid-build.sh
@@ -58,7 +58,7 @@ src_dir="$build_dir/source"
 ndk_dir="$src_dir/ndk"
 work_dir="$build_dir/workspace"
 
-ndkver="android-ndk-r9d"
+ndkver="android-ndk-r10e"
 cpu_arch="$(uname -m)"
 [[ -z "$cpu_arch" ]] && {
     echo "ERROR: NO CPU ARCHITECTURE DETECTED"
@@ -75,11 +75,11 @@ install -d "$work_dir"
 cd "$src_dir"
 [[ -z "$NDK" ]] && {
     if [ -z "$ANDROID_NDK" ]; then
-        echo "$ndkver-linux-${cpu_arch}.tar.bz2"
-        [[ -f "$ndkver-linux-${cpu_arch}.tar.bz2" ]] \
-            || wget "http://dl.google.com/android/ndk/$ndkver-linux-${cpu_arch}.tar.bz2" \
+        echo "$ndkver-linux-${cpu_arch}.bin"
+        [[ -f "$ndkver-linux-${cpu_arch}.bin" ]] \
+            || wget "http://dl.google.com/android/ndk/$ndkver-linux-${cpu_arch}.bin" \
             || (echo "Can't find download for your system" && exit 1)
-        [[ -d "$ndkver" ]] || (tar jxf "$ndkver-linux-${cpu_arch}.tar.bz2" || exit 1)
+        [[ -d "$ndkver" ]] || (chmod a+x $ndkver-linux-${cpu_arch}.bin && ./$ndkver-linux-${cpu_arch}.bin || exit 1)
         NDK="$ndkver"
     else
         NDK="$ANDROID_NDK"
@@ -98,8 +98,8 @@ cd "$src_dir"
 [[ ! -x "$work_dir/android-arm-toolchain/bin/arm-linux-androideabi-gcc" ]] && {
     cd "$src_dir"
     "$ndk_dir/build/tools/make-standalone-toolchain.sh" \
-        --platform=android-9 \
-        --toolchain=arm-linux-androideabi-4.8 \
+        --platform=android-21 \
+        --toolchain=arm-linux-androideabi-4.9 \
         --install-dir="$work_dir/android-arm-toolchain/" \
         --system=linux-$cpu_arch \
             || exit 1

--- a/dht/dhtcore/SearchRunner.c
+++ b/dht/dhtcore/SearchRunner.c
@@ -132,6 +132,11 @@ static void searchReplyCallback(struct RouterModule_Promise* promise,
     struct SearchRunner_Search* search =
         Identity_check((struct SearchRunner_Search*)promise->userData);
 
+    if (!Bits_memcmp(from->ip6.bytes, search->lastNodeAsked.ip6.bytes, 16)) {
+        Timeout_resetTimeout(search->continueSearchTimeout,
+                RouterModule_searchTimeoutMilliseconds(search->runner->router));
+    }
+
     if (!Bits_memcmp(from->ip6.bytes, search->target.ip6.bytes, 16)) {
         search->numFinds++;
     }


### PR DESCRIPTION
Old android-ndk-r9d could not compile the latest cjdns code.
Introduce finer grained permissions by using CAP_TO_MASK, only latest android ndk(android-ndk-r10e) with this feature build-in. 