### PR TITLE
Once got response from lastNodeAsked, reset the search timeout timer

### DIFF
--- a/dht/dhtcore/SearchRunner.c
+++ b/dht/dhtcore/SearchRunner.c
@@ -132,6 +132,11 @@ static void searchReplyCallback(struct RouterModule_Promise* promise,
     struct SearchRunner_Search* search =
         Identity_check((struct SearchRunner_Search*)promise->userData);
 
+    if (!Bits_memcmp(from->ip6.bytes, search->lastNodeAsked.ip6.bytes, 16)) {
+        Timeout_resetTimeout(search->continueSearchTimeout,
+                RouterModule_searchTimeoutMilliseconds(search->runner->router));
+    }
+
     if (!Bits_memcmp(from->ip6.bytes, search->target.ip6.bytes, 16)) {
         search->numFinds++;
     }


### PR DESCRIPTION
Current SearchRunner implementing is corrupted by not reset the search timeout timer, it will cause two searchStep be called at the same time. It cause normal search response be dropped by the lastNodeAsked path check. I found many correct route response is confused by the wrong timer callback.
I change this action by reset the search timer once search response from lastNodeAsked received. 