### PR TITLE
Fix FreeBSD TUNInterface when tunDevice is used

### DIFF
--- a/interface/tuntap/TUNInterface_freebsd.c
+++ b/interface/tuntap/TUNInterface_freebsd.c
@@ -68,7 +68,8 @@ struct Iface* TUNInterface_new(const char* interfaceName,
     int ppa = 0;
     for (uint32_t i = 0; i < strlen(assignedDevname); i++) {
         if (isdigit(assignedDevname[i])) {
-            ppa = atoi(assignedDevname+(i-1));
+            ppa = atoi(assignedDevname+i);
+            break;
         }
     }
 

--- a/interface/tuntap/TUNInterface_freebsd.c
+++ b/interface/tuntap/TUNInterface_freebsd.c
@@ -52,9 +52,9 @@ struct Iface* TUNInterface_new(const char* interfaceName,
 
     // We are on FreeBSD so we just need to read /dev/tunxx to create the tun interface
     if (interfaceName) {
-        sprintf(deviceFile,"/dev/%s",interfaceName);
+        snprintf(deviceFile,TUNInterface_IFNAMSIZ,"/dev/%s",interfaceName);
     } else {
-        sprintf(deviceFile,"%s","/dev/tun");
+        snprintf(deviceFile,TUNInterface_IFNAMSIZ,"%s","/dev/tun");
     }
 
     // Open the descriptor

--- a/interface/tuntap/TUNInterface_freebsd.c
+++ b/interface/tuntap/TUNInterface_freebsd.c
@@ -46,10 +46,19 @@ struct Iface* TUNInterface_new(const char* interfaceName,
                                    struct Except* eh,
                                    struct Allocator* alloc)
 {
+    char deviceFile[TUNInterface_IFNAMSIZ];
+
     if (isTapMode) { Except_throw(eh, "tap mode not supported on this platform"); }
 
+    // We are on FreeBSD so we just need to read /dev/tunxx to create the tun interface
+    if (interfaceName) {
+        sprintf(deviceFile,"/dev/%s",interfaceName);
+    } else {
+        sprintf(deviceFile,"%s","/dev/tun");
+    }
+
     // Open the descriptor
-    int tunFd = open("/dev/tun", O_RDWR);
+    int tunFd = open(deviceFile, O_RDWR);
 
     //Get the resulting device name
     const char* assignedDevname;
@@ -59,7 +68,7 @@ struct Iface* TUNInterface_new(const char* interfaceName,
     int ppa = 0;
     for (uint32_t i = 0; i < strlen(assignedDevname); i++) {
         if (isdigit(assignedDevname[i])) {
-            ppa = atoi(assignedDevname);
+            ppa = atoi(assignedDevname+(i-1));
         }
     }
 


### PR DESCRIPTION
This patch fix the TUNInterface on FreeBSD:
- open /dev/$tunDevice instead of /dev/tun when tunDevice is set
  (FreeBSD will create the tun interface on the open())
- correct the interface number extraction logic.

Tested on FreeBSD 10.1-RELEASE-p10.