### PR TITLE
client: introduce a default admin API password

### DIFF
--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -90,9 +90,6 @@ static int genconf(struct Random* rand, bool eth)
     Random_base32(rand, password3, 32);
     Random_base32(rand, password4, 32);
 
-    uint8_t adminPassword[32];
-    Random_base32(rand, adminPassword, 32);
-
     uint16_t port = 0;
     while (port <= 1024) {
         port = Random_uint16(rand);
@@ -143,11 +140,11 @@ static int genconf(struct Random* rand, bool eth)
            "    // Settings for administering and extracting information from your router.\n"
            "    // This interface provides functions which can be called through a UDP socket.\n"
            "    // See admin/Readme.md for more information about the API and try:\n"
-           "    // ./contrib/python/cexec 'functions'\n"
+           "    // ./tools/cexec\n"
            "    // For a list of functions which can be called.\n"
-           "    // For example:  ./contrib/python/cexec 'memory()'\n"
+           "    // For example: ./tools/cexec 'memory()'\n"
            "    // will call a function which gets the core's current memory consumption.\n"
-           "    // ./contrib/python/cjdnslog\n"
+           "    // ./tools/cjdnslog\n"
            "    // is a tool which uses this admin interface to get logs from cjdns.\n"
            "    \"admin\":\n"
            "    {\n"
@@ -155,7 +152,11 @@ static int genconf(struct Random* rand, bool eth)
            "        \"bind\": \"127.0.0.1:11234\",\n"
            "\n"
            "        // Password for admin RPC server.\n"
-           "        \"password\": \"%s\"\n", adminPassword);
+           "        // This is a static password by default, so that tools like\n"
+           "        // ./tools/cexec can use the API without you creating a\n"
+           "        // config file at ~/.cjdnsadmin first. If you decide to\n"
+           "        // expose the admin API to the network, change the password!\n"
+           "        \"password\": \"NONE\"\n");
     printf("    },\n"
            "\n"
            "    // Interfaces to connect to the switch core.\n"

--- a/contrib/nodejs/cjdnsadmin/cjdnsadmin.js
+++ b/contrib/nodejs/cjdnsadmin/cjdnsadmin.js
@@ -206,11 +206,11 @@ var connect = module.exports.connect = function (addr, port, pass, callback) {
 };
 
 var connectWithAdminInfo = module.exports.connectWithAdminInfo = function (callback) {
-    var cjdnsAdmin;
+    var cjdnsAdmin = {'addr': '127.0.0.1', 'port': 11234, 'password': 'NONE'};
     nThen(function (waitFor) {
         Fs.readFile(process.env.HOME + '/.cjdnsadmin', waitFor(function (err, ret) {
-            if (err) { throw err; }
-            cjdnsAdmin = JSON.parse(String(ret));
+            if (err && err.code != 'ENOENT') { throw err; }
+            if (!err) { cjdnsAdmin = JSON.parse(String(ret)); }
         }));
     }).nThen(function (waitFor) {
         connect(cjdnsAdmin.addr, cjdnsAdmin.port, cjdnsAdmin.password, callback);


### PR DESCRIPTION
Makes the `.cjdnsadmin` config step obsolete. Still allows setting a proper password at will.