### PR TITLE
Make security settings compatible with Windows

### DIFF
--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -458,9 +458,9 @@ static void security(struct Allocator* tempAlloc, List* conf, struct Log* log, s
         Dict* d = Dict_new(tempAlloc);
         Dict_putString(d, String_CONST("user"), String_CONST("nobody"), tempAlloc);
         Dict* ret = NULL;
-//        #if !defined (_WIN32) || !defined (__CYGWIN__) || !defined (__MINGW32__)
+        #if !defined (_WIN32) || !defined (__CYGWIN__) || !defined (__MINGW32__)
             rpcCall0(String_CONST("Security_getUser"), d, ctx, tempAlloc, &ret, true); // This causes cjdns to crash on Windows
-//        #endif
+        #endif
         uid = *Dict_getInt(ret, String_CONST("uid"));
     } while (0);
 

--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -459,7 +459,7 @@ static void security(struct Allocator* tempAlloc, List* conf, struct Log* log, s
         Dict_putString(d, String_CONST("user"), String_CONST("nobody"), tempAlloc);
         Dict* ret = NULL;
         #ifndef _WIN32
-        rpcCall0(String_CONST("Security_getUser"), d, ctx, tempAlloc, &ret, true); // This causes cjdns to crash on Windows
+            rpcCall0(String_CONST("Security_getUser"), d, ctx, tempAlloc, &ret, true); // This causes cjdns to crash on Windows
         #endif
         uid = *Dict_getInt(ret, String_CONST("uid"));
     } while (0);

--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -458,7 +458,7 @@ static void security(struct Allocator* tempAlloc, List* conf, struct Log* log, s
         Dict* d = Dict_new(tempAlloc);
         Dict_putString(d, String_CONST("user"), String_CONST("nobody"), tempAlloc);
         Dict* ret = NULL;
-        #ifndef _WIN32
+        #if !defined (_WIN32) || !defined (__CYGWIN__) || !defined (__MINGW32__)
             rpcCall0(String_CONST("Security_getUser"), d, ctx, tempAlloc, &ret, true); // This causes cjdns to crash on Windows
         #endif
         uid = *Dict_getInt(ret, String_CONST("uid"));

--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -458,9 +458,9 @@ static void security(struct Allocator* tempAlloc, List* conf, struct Log* log, s
         Dict* d = Dict_new(tempAlloc);
         Dict_putString(d, String_CONST("user"), String_CONST("nobody"), tempAlloc);
         Dict* ret = NULL;
-        #if !defined (_WIN32) || !defined (__CYGWIN__) || !defined (__MINGW32__)
+//        #if !defined (_WIN32) || !defined (__CYGWIN__) || !defined (__MINGW32__)
             rpcCall0(String_CONST("Security_getUser"), d, ctx, tempAlloc, &ret, true); // This causes cjdns to crash on Windows
-        #endif
+//        #endif
         uid = *Dict_getInt(ret, String_CONST("uid"));
     } while (0);
 

--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -458,7 +458,9 @@ static void security(struct Allocator* tempAlloc, List* conf, struct Log* log, s
         Dict* d = Dict_new(tempAlloc);
         Dict_putString(d, String_CONST("user"), String_CONST("nobody"), tempAlloc);
         Dict* ret = NULL;
-        rpcCall0(String_CONST("Security_getUser"), d, ctx, tempAlloc, &ret, true);
+        #ifndef _WIN32
+        rpcCall0(String_CONST("Security_getUser"), d, ctx, tempAlloc, &ret, true); // This causes cjdns to crash on Windows
+        #endif
         uid = *Dict_getInt(ret, String_CONST("uid"));
     } while (0);
 

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -307,7 +307,7 @@ static int genconf(struct Random* rand, bool eth)
            "        // and ETHInterface will be unable to hot-add new interfaces\n"
            "        // Use { \"setuser\": 0 } to disable.\n"
            "        // Default: enabled with keepNetAdmin\n"
-#ifdef _WIN32
+#if defined (_WIN32) || defined (__CYGWIN__) || defined (__MINGW32__)
            "        { \"setuser\": 0, \"keepNetAdmin\": 1 },\n"
 #else
            "        { \"setuser\": \"nobody\", \"keepNetAdmin\": 1 },\n"
@@ -318,7 +318,7 @@ static int genconf(struct Random* rand, bool eth)
            "        // have permission to use chroot(), this will fail quietly.\n"
            "        // Use { \"chroot\": 0 } to disable.\n"
            "        // Default: enabled (using \"/var/run\")\n"
-#ifdef _WIN32
+#if defined (_WIN32) || defined (__CYGWIN__) || defined (__MINGW32__)
            "        { \"chroot\": 0 },\n"
 #else
            "        { \"chroot\": \"/var/run/\" },\n"
@@ -341,7 +341,7 @@ static int genconf(struct Random* rand, bool eth)
            "        // linux system, strictly limiting it's access to the outside world\n"
            "        // This will fail quietly on any non-linux system\n"
            "        // Default: enabled\n"
-#ifdef _WIN32
+#if defined (_WIN32) || defined (__CYGWIN__) || defined (__MINGW32__)
            "        { \"seccomp\": 0 },\n"
 #else
            "        { \"seccomp\": 1 },\n"
@@ -368,11 +368,11 @@ static int genconf(struct Random* rand, bool eth)
            "    // If set to non-zero, cjdns will not fork to the background.\n"
            "    // Recommended for use in conjunction with \"logTo\":\"stdout\".\n"
            "    // On Windows, cjdns will crash without this.\n"
-           #ifdef _WIN32
+#if defined (_WIN32) || defined (__CYGWIN__) || defined (__MINGW32__)
            "    \"noBackground\":1,\n"
-           #else
+#else
            "    \"noBackground\":0,\n"
-           #endif
+#endif
            "}\n");
 
     return 0;

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -307,22 +307,22 @@ static int genconf(struct Random* rand, bool eth)
            "        // and ETHInterface will be unable to hot-add new interfaces\n"
            "        // Use { \"setuser\": 0 } to disable.\n"
            "        // Default: enabled with keepNetAdmin\n"
-           #ifdef _WIN32
+#ifdef _WIN32
            "        { \"setuser\": 0, \"keepNetAdmin\": 1 },\n"
-           #else
+#else
            "        { \"setuser\": \"nobody\", \"keepNetAdmin\": 1 },\n"
-           #endif
+#endif
            "\n"
            "        // Chroot changes the filesystem root directory which cjdns sees, blocking it\n"
            "        // from accessing files outside of the chroot sandbox, if the user does not\n"
            "        // have permission to use chroot(), this will fail quietly.\n"
            "        // Use { \"chroot\": 0 } to disable.\n"
            "        // Default: enabled (using \"/var/run\")\n"
-           #ifdef _WIN32
+#ifdef _WIN32
            "        { \"chroot\": 0 },\n"
-           #else
+#else
            "        { \"chroot\": \"/var/run/\" },\n"
-           #endif
+#endif
            "\n"
            "        // Nofiles is a deprecated security feature which prevents cjdns from opening\n"
            "        // any files at all, using this will block setting of IP addresses and\n"
@@ -341,11 +341,11 @@ static int genconf(struct Random* rand, bool eth)
            "        // linux system, strictly limiting it's access to the outside world\n"
            "        // This will fail quietly on any non-linux system\n"
            "        // Default: enabled\n"
-           #ifdef _WIN32
+#ifdef _WIN32
            "        { \"seccomp\": 0 },\n"
-           #else
+#else
            "        { \"seccomp\": 1 },\n"
-           #endif
+#endif
            "\n"
            "        // The client sets up the core using a sequence of RPC calls, the responses\n"
            "        // to these calls are verified but in the event that the client crashes\n"

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -298,6 +298,8 @@ static int genconf(struct Random* rand, bool eth)
            "    // Counter-intuitively, cjdns is *more* secure if it is started as root because\n"
            "    // non-root users do not have permission to use chroot or change usernames,\n"
            "    // limiting the effectiveness of the mitigations herein.\n"
+           "    // Certain security features are disabled by default when compiling for Windows\n"
+           "    // due to compatibility issues.\n"
            "    \"security\":\n"
            "    [\n"
            "        // Change the user id to sandbox the cjdns process after it starts.\n"
@@ -305,14 +307,22 @@ static int genconf(struct Random* rand, bool eth)
            "        // and ETHInterface will be unable to hot-add new interfaces\n"
            "        // Use { \"setuser\": 0 } to disable.\n"
            "        // Default: enabled with keepNetAdmin\n"
+           #ifdef _WIN32
+           "        { \"setuser\": 0, \"keepNetAdmin\": 1 },\n"
+           #else
            "        { \"setuser\": \"nobody\", \"keepNetAdmin\": 1 },\n"
+           #endif
            "\n"
            "        // Chroot changes the filesystem root directory which cjdns sees, blocking it\n"
            "        // from accessing files outside of the chroot sandbox, if the user does not\n"
            "        // have permission to use chroot(), this will fail quietly.\n"
            "        // Use { \"chroot\": 0 } to disable.\n"
            "        // Default: enabled (using \"/var/run\")\n"
+           #ifdef _WIN32
+           "        { \"chroot\": 0 },\n"
+           #else
            "        { \"chroot\": \"/var/run/\" },\n"
+           #endif
            "\n"
            "        // Nofiles is a deprecated security feature which prevents cjdns from opening\n"
            "        // any files at all, using this will block setting of IP addresses and\n"
@@ -331,7 +341,11 @@ static int genconf(struct Random* rand, bool eth)
            "        // linux system, strictly limiting it's access to the outside world\n"
            "        // This will fail quietly on any non-linux system\n"
            "        // Default: enabled\n"
+           #ifdef _WIN32
+           "        { \"seccomp\": 0 },\n"
+           #else
            "        { \"seccomp\": 1 },\n"
+           #endif
            "\n"
            "        // The client sets up the core using a sequence of RPC calls, the responses\n"
            "        // to these calls are verified but in the event that the client crashes\n"
@@ -353,7 +367,12 @@ static int genconf(struct Random* rand, bool eth)
            "\n"
            "    // If set to non-zero, cjdns will not fork to the background.\n"
            "    // Recommended for use in conjunction with \"logTo\":\"stdout\".\n"
+           "    // On Windows, cjdns will crash without this.\n"
+           #ifdef _WIN32
+           "    \"noBackground\":1,\n"
+           #else
            "    \"noBackground\":0,\n"
+           #endif
            "}\n");
 
     return 0;


### PR DESCRIPTION
Disable some unsupported security features by default in config and not call Security_getUser when running windows.
Sorry for any mistakes, I am not a professional programmer.
I have no idea why it isn't compiling, there doesn't seem to be any error messages.