### PR TITLE
Fix interface name default encoding for windows

### DIFF
--- a/util/platform/netdev/NetPlatform_win32.c
+++ b/util/platform/netdev/NetPlatform_win32.c
@@ -57,7 +57,7 @@ static NET_LUID getLuid(const char* name, struct Except* eh)
 {
     uint16_t ifName[IF_MAX_STRING_SIZE + 1] = {0};
     WinFail_check(eh,
-        (!MultiByteToWideChar(CP_UTF8, 0, name, strlen(name), ifName, IF_MAX_STRING_SIZE + 1))
+        (!MultiByteToWideChar(CP_ACP, 0, name, strlen(name), ifName, IF_MAX_STRING_SIZE + 1))
     );
     NET_LUID out;
     WinFail_check(eh, ConvertInterfaceAliasToLuid(ifName, &out));


### PR DESCRIPTION
It seems windows use CP_ACP but not CP_UTF8 encoding to store the interface name/alias in the registry. I test the change on my win8 workstation. Need more different locale to test this change.