### PR TITLE
Prevent mkdir from erroring if /dev/net exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 #### *Networking Reinvented*
 
 Cjdns implements an encrypted IPv6 network using public-key cryptography for
-address allocation and a distributed hash table for routing. This providesmkdir
+address allocation and a distributed hash table for routing. This provides
 near-zero-configuration networking, and prevents many of the security and
 scalability issues that plague existing networks.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 #### *Networking Reinvented*
 
 Cjdns implements an encrypted IPv6 network using public-key cryptography for
-address allocation and a distributed hash table for routing. This provides
+address allocation and a distributed hash table for routing. This providesmkdir
 near-zero-configuration networking, and prevents many of the security and
 scalability issues that plague existing networks.
 
@@ -181,7 +181,7 @@ If it says: `cat: /dev/net/tun: File descriptor in bad state` Good!
 
 If it says: `cat: /dev/net/tun: No such file or directory`, create it using:
 
-    sudo mkdir /dev/net &&
+    sudo mkdir -p /dev/net &&
     sudo mknod /dev/net/tun c 10 200 &&
     sudo chmod 0666 /dev/net/tun
 


### PR DESCRIPTION
mkdir /dev/net returns with a non-zero exit code and blocks the mknod and chmod commands if /dev/net exists. -p fixes this by recursively trying to create /dev/net and not throwing an error if the directories exist.