### PR TITLE
Try to fix expired node in NodeStore link

### DIFF
--- a/dht/dhtcore/Janitor.c
+++ b/dht/dhtcore/Janitor.c
@@ -307,18 +307,6 @@ static void peersResponseCallback(struct RouterModule_Promise* promise,
                     continue;
                 }
 
-                /*
-                // If it's not required for keyspace, then check if it can split a path.
-                node = NodeStore_getNextNode(janitor->nodeStore, NULL);
-                while (node) {
-                    if (LabelSplicer_routesThrough(node->address.path, addresses->elems[i].path)) {
-                        RumorMill_addNode(janitor->pub.nodeMill, &addresses->elems[i]);
-                        break;
-                    }
-                    node = NodeStore_getNextNode(janitor->nodeStore, node);
-                }
-                */
-
                 // Check if this node can split an existing link.
                 struct Node_Link* link = NULL;
                 while ((link = NodeStore_nextLink(parent, link))) {
@@ -328,6 +316,12 @@ static void peersResponseCallback(struct RouterModule_Promise* promise,
                                                              link->cannonicalLabel);
                     if (!LabelSplicer_routesThrough(label, addresses->elems[i].path)) { continue; }
                     RumorMill_addNode(janitor->pub.nodeMill, &addresses->elems[i]);
+                    break;
+                }
+
+                // We got peer response but not added to nodeMill, so launch a search here
+                if (link == NULL) {
+                    searchNoDupe(addresses->elems[i].ip6.bytes, janitor);
                 }
             }
         } else if (!Address_isSameIp(&addresses->elems[i], &nl->child->address)) {


### PR DESCRIPTION
Scene description:
A laptop connected with one inbound node at business time, once the other nodes in cjdnet got the valid link path, the laptop offline at life time. When the next day the same laptop online again, its link path is changed when it connect to the same inbound node. But the status of link path in other's nodestore has already became to INVALID(v16.ffff.ffff.ffff.ffff.xxxxx) for timeout issue.
I cound not find any other proper place to fix this issue, so I launch a new search action once the node get peer response which include this node.