### PR TITLE
Fix expired node in NodeStore not sync with SessionManager

### DIFF
--- a/dht/Pathfinder.c
+++ b/dht/Pathfinder.c
@@ -368,14 +368,14 @@ static Iface_DEFUN syncNode(struct Message* msg, struct Pathfinder_pvt* pf)
     uint8_t addr[16];
     Message_pop(msg, addr, 16, NULL);
     Assert_true(!msg->length);
-    {
+    if (Defined(Log_DEBUG)) {
         uint8_t printedAddr[40];
         AddrTools_printIp(printedAddr, addr);
         Log_debug(pf->log, "Sync node [%s]", printedAddr);
     }
 
     // Destory node which not sync with SessionManager
-    NodeStore_destroyNode(pf->nodeStore, addr);
+    NodeStore_destroyNodeIfNoKnownPath(pf->nodeStore, addr);
     return NULL;
 }
 

--- a/dht/Pathfinder.c
+++ b/dht/Pathfinder.c
@@ -363,6 +363,22 @@ static Iface_DEFUN handlePong(struct Message* msg, struct Pathfinder_pvt* pf)
     return NULL;
 }
 
+static Iface_DEFUN syncNode(struct Message* msg, struct Pathfinder_pvt* pf)
+{
+    uint8_t addr[16];
+    Message_pop(msg, addr, 16, NULL);
+    Assert_true(!msg->length);
+    {
+        uint8_t printedAddr[40];
+        AddrTools_printIp(printedAddr, addr);
+        Log_debug(pf->log, "Sync node [%s]", printedAddr);
+    }
+
+    // Destory node which not sync with SessionManager
+    NodeStore_destroyNode(pf->nodeStore, addr);
+    return NULL;
+}
+
 static Iface_DEFUN incomingMsg(struct Message* msg, struct Pathfinder_pvt* pf)
 {
     struct Address addr;
@@ -415,6 +431,7 @@ static Iface_DEFUN incomingFromEventIf(struct Message* msg, struct Iface* eventI
         case PFChan_Core_MSG: return incomingMsg(msg, pf);
         case PFChan_Core_PING: return handlePing(msg, pf);
         case PFChan_Core_PONG: return handlePong(msg, pf);
+        case PFChan_Core_SYNC_NODE: return syncNode(msg, pf);
         default:;
     }
     Assert_failure("unexpected event [%d]", ev);

--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -2443,14 +2443,16 @@ uint64_t NodeStore_timeSinceLastPing(struct NodeStore* nodeStore, struct Node_Tw
     return now - lastSeen;
 }
 
-void NodeStore_destroyNode(struct NodeStore* nodeStore, uint8_t* addr)
+void NodeStore_destroyNodeIfNoKnownPath(struct NodeStore* nodeStore, uint8_t* addr)
 {
     struct NodeStore_pvt* store = Identity_check((struct NodeStore_pvt*)nodeStore);
     struct Node_Two* n = nodeForIp(store, addr);
     if (n && n->address.path == UINT64_MAX) {
-        uint8_t printedAddr[40];
-        AddrTools_printIp(printedAddr, addr);
-        Log_debug(store->logger, "Cleanup node %s.\n", printedAddr);
+        if (Defined(Log_DEBUG)) {
+            uint8_t printedAddr[40];
+            AddrTools_printIp(printedAddr, addr);
+            Log_debug(store->logger, "Cleanup node %s.\n", printedAddr);
+        }
         destroyNode(n, store);
         freePendingLinks(store);
     }

--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -2442,3 +2442,17 @@ uint64_t NodeStore_timeSinceLastPing(struct NodeStore* nodeStore, struct Node_Tw
     }
     return now - lastSeen;
 }
+
+void NodeStore_destroyNode(struct NodeStore* nodeStore, uint8_t* addr)
+{
+    struct NodeStore_pvt* store = Identity_check((struct NodeStore_pvt*)nodeStore);
+    struct Node_Two* n = nodeForIp(store, addr);
+    if (n && n->address.path == UINT64_MAX) {
+        uint8_t printedAddr[40];
+        AddrTools_printIp(printedAddr, addr);
+        Log_debug(store->logger, "Cleanup node %s.\n", printedAddr);
+        destroyNode(n, store);
+        freePendingLinks(store);
+    }
+    return;
+}

--- a/dht/dhtcore/NodeStore.h
+++ b/dht/dhtcore/NodeStore.h
@@ -217,6 +217,8 @@ struct Node_Link* NodeStore_getNextLink(struct NodeStore* nodeStore, struct Node
 
 uint64_t NodeStore_timeSinceLastPing(struct NodeStore* nodeStore, struct Node_Two* node);
 
+void NodeStore_destroyNode(struct NodeStore* nodeStore, uint8_t* addr);
+
 // Used for DHT maintenance.
 #define NodeStore_bucketSize 4
 #define NodeStore_bucketNumber 128

--- a/dht/dhtcore/NodeStore.h
+++ b/dht/dhtcore/NodeStore.h
@@ -217,7 +217,7 @@ struct Node_Link* NodeStore_getNextLink(struct NodeStore* nodeStore, struct Node
 
 uint64_t NodeStore_timeSinceLastPing(struct NodeStore* nodeStore, struct Node_Two* node);
 
-void NodeStore_destroyNode(struct NodeStore* nodeStore, uint8_t* addr);
+void NodeStore_destroyNodeIfNoKnownPath(struct NodeStore* nodeStore, uint8_t* addr);
 
 // Used for DHT maintenance.
 #define NodeStore_bucketSize 4

--- a/net/EventEmitter.c
+++ b/net/EventEmitter.c
@@ -152,13 +152,16 @@ static bool PFChan_Core_sizeOk(enum PFChan_Core ev, int size)
         case PFChan_Core_PING:
         case PFChan_Core_PONG:
             return (size == 8 + PFChan_Ping_SIZE);
+
+        case PFChan_Core_SYNC_NODE:
+            return (size == 8 + PFChan_Core_SyncNode_SIZE);
         default:;
     }
     Assert_failure("invalid event [%d]", ev);
 }
 // Remember to add the event to this function too!
 Assert_compileTime(PFChan_Core__TOO_LOW == 1023);
-Assert_compileTime(PFChan_Core__TOO_HIGH == 1037);
+Assert_compileTime(PFChan_Core__TOO_HIGH == 1038);
 
 static Iface_DEFUN incomingFromCore(struct Message* msg, struct Iface* trickIf)
 {

--- a/net/SessionManager.h
+++ b/net/SessionManager.h
@@ -79,6 +79,12 @@ struct SessionManager
      */
     #define SessionManager_SESSION_SEARCH_AFTER_MILLISECONDS_DEFAULT 100000
     int64_t sessionSearchAfterMilliseconds;
+
+    /** Number of milliseconds after which a SYNC will be run to sync a session node with DHT
+     * NodeStore node.
+     */
+    #define SessionManager_SESSION_SYNC_AFTER_MILLISECONDS_DEFAULT 30000
+    int64_t sessionSyncAfterMilliseconds;
 };
 
 struct SessionManager_Session
@@ -97,6 +103,9 @@ struct SessionManager_Session
 
     /** This is the time the last search was triggered for this session. */
     int64_t lastSearchTime;
+
+    /** This is the time the last sync was triggered for this session. */
+    int64_t lastSyncTime;
 
     /** The handle which will be used to lookup this session on our side. */
     uint32_t receiveHandle;

--- a/wire/PFChan.h
+++ b/wire/PFChan.h
@@ -260,7 +260,13 @@ enum PFChan_Core
      */
     PFChan_Core_PONG = 1036,
 
-    PFChan_Core__TOO_HIGH = 1037,
+    /**
+     * Emitted when SessionManager want to sync node with pathfinder NodeStore
+     * (emitted by: EventEmitter.c)
+     */
+    PFChan_Core_SYNC_NODE = 1037,
+
+    PFChan_Core__TOO_HIGH = 1038,
 };
 
 struct PFChan_Core_SearchReq
@@ -310,6 +316,13 @@ struct PFChan_Core_SwitchErr
     (SwitchHeader_SIZE + 4 + Control_Header_SIZE + Control_Error_MIN_SIZE)
 Assert_compileTime(sizeof(struct PFChan_Core_SwitchErr) == PFChan_Core_SwitchErr_MIN_SIZE);
 
+struct PFChan_Core_SyncNode
+{
+    uint8_t ipv6[16];
+};
+#define PFChan_Core_SyncNode_SIZE 16
+Assert_compileTime(sizeof(struct PFChan_Core_SyncNode) == PFChan_Core_SyncNode_SIZE);
+
 struct PFChan_FromCore
 {
     enum PFChan_Core event_be;
@@ -331,6 +344,7 @@ struct PFChan_FromCore
         struct PFChan_Msg msg;
         struct PFChan_Ping ping;
         struct PFChan_Ping pong;
+        struct PFChan_Core_SyncNode syncNode;
         uint8_t bytes[4];
     } content;
 };


### PR DESCRIPTION
Every 30 seconds, the SessionManage will sync the established nodes with the Pathfinder NodeStore nodes.
If the node in NodeStore is invalid state but it is established in SessionManage, the expired node will be destroyed from the NodeStore.