### PR TITLE
Outbound users

### DIFF
--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -131,14 +131,14 @@ static int genconf(struct Random* rand, bool eth)
            "        // Below is an example of your connection credentials\n"
            "        // that you can give to other people so they can connect\n"
            "        // to you using your default password (from above).\n"
-           "        // The user field here identifies your node to your peer.\n"
+           "        // The peerName field here identifies your node to your peer.\n"
            "        // Adding a unique password for each peer is advisable\n"
            "        // so that leaks can be isolated.\n"
            "        //\n"
            "        // \"your.external.ip.goes.here:%u\":{", port);
     printf("\"password\":\"%s\",", password);
     printf("\"publicKey\":\"%s.k\",", publicKeyBase32);
-    printf("\"user\":\"your-name-not-password's-user\"},\n");
+    printf("\"peerName\":\"your-name-goes-here\"},\n");
     printf("    ],\n"
            "\n"
            "    // Settings for administering and extracting information from your router.\n"
@@ -184,7 +184,7 @@ static int genconf(struct Random* rand, bool eth)
            "                    //     \"publicKey\": \"remote node key.k\",\n"
            "                    //     // And optionally:\n"
            "                    //     \"ipv6\": \"derived from key with publictoip6\",\n"
-           "                    //     \"user\": \"human-readable display name for peer\"\n"
+           "                    //     \"peerName\": \"human-readable display name for peer\"\n"
            "                    // },\n"
            "                    // Ask somebody who is already connected.\n"
            "                }\n"

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -113,28 +113,32 @@ static int genconf(struct Random* rand, bool eth)
            "    // WARNING: Currently there is no key derivation done on the password field,\n"
            "    //          DO NOT USE A PASSWORD HERE use something which is truly random and\n"
            "    //          cannot be guessed.\n"
-           "    // Including a username in the beginning of the password string is encouraged\n"
-           "    // to aid in remembering which users are who.\n"
+           "    // Setting the user field is encouraged to aid in remembering which users are\n"
+           "    // who.\n"
            "    //\n"
            "    \"authorizedPasswords\":\n"
            "    [\n"
            "        // A unique string which is known to the client and server.\n"
-           "        {\"password\": \"%s\"}\n", password);
+           "        // Specify an optional user to identify the peer locally.\n"
+           "        // It is not used for authentication.\n"
+           "        {\"password\": \"%s\", \"user\": \"my-first-peer\"}\n", password);
     printf("\n"
            "        // More passwords should look like this.\n"
-           "        // {\"password\": \"%s\"},\n", password2);
-    printf("        // {\"password\": \"%s\"},\n", password3);
-    printf("        // {\"password\": \"%s\"},\n", password4);
+           "        // {\"password\": \"%s\", \"user\": \"my-second-peer\"},\n", password2);
+    printf("        // {\"password\": \"%s\", \"user\": \"my-third-peer\"},\n", password3);
+    printf("        // {\"password\": \"%s\", \"user\": \"my-fourth-peer\"},\n", password4);
     printf("\n"
            "        // Below is an example of your connection credentials\n"
            "        // that you can give to other people so they can connect\n"
-           "        // to you using your default password (from above)\n"
-           "        // Adding a unique password for each user is advisable\n"
+           "        // to you using your default password (from above).\n"
+           "        // The user field here identifies your node to your peer.\n"
+           "        // Adding a unique password for each peer is advisable\n"
            "        // so that leaks can be isolated.\n"
            "        //\n"
            "        // \"your.external.ip.goes.here:%u\":{", port);
     printf("\"password\":\"%s\",", password);
-    printf("\"publicKey\":\"%s.k\"}\n", publicKeyBase32);
+    printf("\"publicKey\":\"%s.k\",", publicKeyBase32);
+    printf("\"user\":\"your-name-not-password's-user\"},\n");
     printf("    ],\n"
            "\n"
            "    // Settings for administering and extracting information from your router.\n"
@@ -173,6 +177,15 @@ static int genconf(struct Random* rand, bool eth)
            "                \"connectTo\":\n"
            "                {\n"
            "                    // Add connection credentials here to join the network\n"
+           "                    // If you have several, don't forget the separating commas\n"
+           "                    // They should look like:\n"
+           "                    // \"ipv4 address:port\": {\n"
+           "                    //     \"password\": \"password to connect with\",\n"
+           "                    //     \"publicKey\": \"remote node key.k\",\n"
+           "                    //     // And optionally:\n"
+           "                    //     \"ipv6\": \"derived from key with publictoip6\",\n"
+           "                    //     \"user\": \"human-readable display name for peer\"\n"
+           "                    // },\n"
            "                    // Ask somebody who is already connected.\n"
            "                }\n"
            "            },\n"

--- a/crypto/CryptoAuth.c
+++ b/crypto/CryptoAuth.c
@@ -770,7 +770,9 @@ static USE_RES int decryptHandshake(struct CryptoAuth_Session_pvt* session,
             Assert_true(session->nextNonce <= nextNonce);
             session->nextNonce = nextNonce;
 
-            session->pub.userName = user;
+            if (!session->pub.userName) {
+                session->pub.userName = user;
+            }
             Bits_memcpyConst(session->herTempPubKey, header->handshake.encryptedTempKey, 32);
         } else {
             // It's a (possibly repeat) key packet and we have begun sending run data.
@@ -809,7 +811,9 @@ static USE_RES int decryptHandshake(struct CryptoAuth_Session_pvt* session,
 
         Assert_true(session->nextNonce <= nextNonce);
         session->nextNonce = nextNonce;
-        session->pub.userName = user;
+        if (!session->pub.userName) {
+            session->pub.userName = user;
+        }
         if (restrictedToip6) {
             Bits_memcpyConst(session->pub.herIp6, restrictedToip6, 16);
         }
@@ -824,7 +828,9 @@ static USE_RES int decryptHandshake(struct CryptoAuth_Session_pvt* session,
 
         Assert_true(session->nextNonce <= nextNonce);
         session->nextNonce = nextNonce;
-        session->pub.userName = user;
+        if (!session->pub.userName) {
+            session->pub.userName = user;
+        }
         if (restrictedToip6) {
             Bits_memcpyConst(session->pub.herIp6, restrictedToip6, 16);
         }

--- a/interface/ETHInterface_admin.c
+++ b/interface/ETHInterface_admin.c
@@ -45,6 +45,8 @@ static void beginConnection(Dict* args,
     String* macAddress = Dict_getString(args, String_CONST("macAddress"));
     int64_t* interfaceNumber = Dict_getInt(args, String_CONST("interfaceNumber"));
     uint32_t ifNum = (interfaceNumber) ? ((uint32_t) *interfaceNumber) : 0;
+    // This is the user to display the remote end as, not a login user
+    String* user = Dict_getString(args, String_CONST("user"));
     char* error = "none";
 
     uint8_t pkBytes[32];
@@ -61,7 +63,7 @@ static void beginConnection(Dict* args,
         error = "invalid macAddress";
     } else {
         int ret = InterfaceController_bootstrapPeer(
-            ctx->ic, ifNum, pkBytes, &sockaddr.generic, password, ctx->alloc);
+            ctx->ic, ifNum, pkBytes, &sockaddr.generic, password, user, ctx->alloc);
 
         if (ret == InterfaceController_bootstrapPeer_BAD_IFNUM) {
             error = "invalid interfaceNumber";

--- a/interface/ETHInterface_admin.c
+++ b/interface/ETHInterface_admin.c
@@ -45,8 +45,7 @@ static void beginConnection(Dict* args,
     String* macAddress = Dict_getString(args, String_CONST("macAddress"));
     int64_t* interfaceNumber = Dict_getInt(args, String_CONST("interfaceNumber"));
     uint32_t ifNum = (interfaceNumber) ? ((uint32_t) *interfaceNumber) : 0;
-    // This is the user to display the remote end as, not a login user
-    String* user = Dict_getString(args, String_CONST("user"));
+    String* peerName = Dict_getString(args, String_CONST("peerName"));
     char* error = "none";
 
     uint8_t pkBytes[32];
@@ -63,7 +62,7 @@ static void beginConnection(Dict* args,
         error = "invalid macAddress";
     } else {
         int ret = InterfaceController_bootstrapPeer(
-            ctx->ic, ifNum, pkBytes, &sockaddr.generic, password, user, ctx->alloc);
+            ctx->ic, ifNum, pkBytes, &sockaddr.generic, password, peerName, ctx->alloc);
 
         if (ret == InterfaceController_bootstrapPeer_BAD_IFNUM) {
             error = "invalid interfaceNumber";

--- a/interface/UDPInterface_admin.c
+++ b/interface/UDPInterface_admin.c
@@ -44,8 +44,7 @@ static void beginConnection(Dict* args,
     String* address = Dict_getString(args, String_CONST("address"));
     int64_t* interfaceNumber = Dict_getInt(args, String_CONST("interfaceNumber"));
     uint32_t ifNum = (interfaceNumber) ? ((uint32_t) *interfaceNumber) : 0;
-    // This is the user to display the remote end as, not a login user
-    String* user = Dict_getString(args, String_CONST("user"));
+    String* peerName = Dict_getString(args, String_CONST("peerName"));
     String* error = NULL;
 
     Log_debug(ctx->logger, "Peering with [%s]", publicKey->bytes);
@@ -85,7 +84,7 @@ static void beginConnection(Dict* args,
         }
 
         int ret = InterfaceController_bootstrapPeer(
-            ctx->ic, ifNum, pkBytes, addr, password, user, ctx->alloc);
+            ctx->ic, ifNum, pkBytes, addr, password, peerName, ctx->alloc);
 
         Allocator_free(tempAlloc);
 

--- a/interface/UDPInterface_admin.c
+++ b/interface/UDPInterface_admin.c
@@ -44,6 +44,8 @@ static void beginConnection(Dict* args,
     String* address = Dict_getString(args, String_CONST("address"));
     int64_t* interfaceNumber = Dict_getInt(args, String_CONST("interfaceNumber"));
     uint32_t ifNum = (interfaceNumber) ? ((uint32_t) *interfaceNumber) : 0;
+    // This is the user to display the remote end as, not a login user
+    String* user = Dict_getString(args, String_CONST("user"));
     String* error = NULL;
 
     Log_debug(ctx->logger, "Peering with [%s]", publicKey->bytes);
@@ -82,8 +84,8 @@ static void beginConnection(Dict* args,
             Sockaddr_setPort(addr, Sockaddr_getPort(&ss.addr));
         }
 
-        int ret =
-            InterfaceController_bootstrapPeer(ctx->ic, ifNum, pkBytes, addr, password, ctx->alloc);
+        int ret = InterfaceController_bootstrapPeer(
+            ctx->ic, ifNum, pkBytes, addr, password, user, ctx->alloc);
 
         Allocator_free(tempAlloc);
 

--- a/net/Benchmark.c
+++ b/net/Benchmark.c
@@ -174,6 +174,7 @@ static void switching(struct Context* ctx)
                                                 bob->ca->publicKey,
                                                 Sockaddr_LOOPBACK,
                                                 String_CONST("abcdefg123"),
+                                                NULL,
                                                 alloc);
     Assert_true(!ret);
 

--- a/net/InterfaceController.c
+++ b/net/InterfaceController.c
@@ -805,6 +805,7 @@ int InterfaceController_bootstrapPeer(struct InterfaceController* ifc,
                                       uint8_t* herPublicKey,
                                       const struct Sockaddr* lladdrParm,
                                       String* password,
+                                      String* user,
                                       struct Allocator* alloc)
 {
     struct InterfaceController_pvt* ic = Identity_check((struct InterfaceController_pvt*) ifc);
@@ -849,6 +850,9 @@ int InterfaceController_bootstrapPeer(struct InterfaceController* ifc,
     ep->caSession =
         CryptoAuth_newSession(ic->ca, epAlloc, herPublicKey, ep->addr.ip6.bytes, false, "outer");
     CryptoAuth_setAuth(password, 1, ep->caSession);
+    if (user) {
+        ep->caSession->userName = String_clone(user, epAlloc);
+    }
 
     ep->switchIf.send = sendFromSwitch;
 

--- a/net/InterfaceController.h
+++ b/net/InterfaceController.h
@@ -130,6 +130,7 @@ struct InterfaceController_Iface* InterfaceController_newIface(struct InterfaceC
  * @param herPublicKey the public key of the foreign node, NULL if unknown.
  * @param lladdr the link level address, must be the size given by the interface for interfaceNumber
  * @param password the password for authenticating with the other node.
+ * @param user the username to assign the other node in the CryptoAuth session. May be null.
  * @param alloc the peer will be dropped if this is freed.
  *
  * @return 0 if all goes well.
@@ -147,6 +148,7 @@ int InterfaceController_bootstrapPeer(struct InterfaceController* ifc,
                                       uint8_t* herPublicKey,
                                       const struct Sockaddr* lladdr,
                                       String* password,
+                                      String* user,
                                       struct Allocator* alloc);
 
 #define InterfaceController_beaconState_newState_OFF    0

--- a/test/TestFramework.c
+++ b/test/TestFramework.c
@@ -194,6 +194,7 @@ void TestFramework_linkNodes(struct TestFramework* client,
                                    server->publicKey,
                                    Sockaddr_LOOPBACK,
                                    String_CONST("abcdefg123"),
+                                   NULL,
                                    client->alloc);
     }
 }


### PR DESCRIPTION
For a while there has been a secret feature where you can add a `user` field to the objects in `authorizedPasswords` and have it come out in the output of tools like `peerStats` to identify the peers that log into your node. This is super useful for figuring out which of your peers are connected; you don't have to keep referring back to the only-root-can-read-it config file and counting the passwords to figure out who is connected and who isn't.

This PR adds the same functionality to outbound connections. If a `connectTo` entry has a `user` field, it will get squirreled away in the `userName` of the relevant `CryptoAuth_Session`, and eventually make it out through the API that `peerStats` uses, so you can have human-readable names for your outgoing peerings as well as your incoming ones. Very useful for finding out who you have to complain at on IRC.

This PR also publicizes the user feature by adding examples of it in newly generated config files.