### PR TITLE
Fix #819

### DIFF
--- a/crypto/random/seed/GetEntropyRandomSeed.h
+++ b/crypto/random/seed/GetEntropyRandomSeed.h
@@ -20,6 +20,7 @@
 #include "memory/Allocator.h"
 #include "util/Linker.h"
 
+#ifndef _WIN32
 #include <sys/syscall.h>
 
 #if defined __OPENBSD__ || defined SYS_getrandom
@@ -28,4 +29,5 @@
     RandomSeedProvider_register(GetEntropyRandomSeed_new)
 #endif
 
+#endif
 #endif


### PR DESCRIPTION
GetEntropyRandomSeed.h incudes \<sys/syscall.h\> which is not available in
Windows enviroment.

By using _WIN32 preprocessor definition we disable this
inclusion from happening in Windows based systems. _WIN32 is defined
in cygwin and mingw enviroments.

It is not possible, from the preprocessor, to check for header file.
It could be done from buildscript but current solution works as well.