### PR TITLE
Fix AppArmor profile so cjdroute can chroot

### DIFF
--- a/contrib/apparmor/usr.sbin.cjdroute
+++ b/contrib/apparmor/usr.sbin.cjdroute
@@ -14,6 +14,7 @@
     capability net_admin,
     capability net_raw,
     capability setuid,
+    capability sys_chroot,
 
 
 


### PR DESCRIPTION
The old AppArmor profile was blocking chroot calls from Security.c.

This fix resolves this error when using AppArmor:
> [Security.c:117 chroot(/var/run/) -> [Operation not permitted]] calling [Security_chroot], ignoring. 

Syslog:
> apparmor="DENIED" operation="capable" profile="/usr/sbin/cjdroute" pid=16148 comm="cjdroute" capability=18  capname="sys_chroot"