### PR TITLE
anonymous connect api should use .cjdnsadmin but not hardcode ip/port

### DIFF
--- a/contrib/nodejs/cjdnsadmin/cjdnsadmin.js
+++ b/contrib/nodejs/cjdnsadmin/cjdnsadmin.js
@@ -218,10 +218,9 @@ var connectWithAdminInfo = module.exports.connectWithAdminInfo = function (callb
 };
 
 var connectAsAnon = module.exports.connectAsAnon = function (callback, addr, port) {
-    var cjdnsAdmin = {'addr': '127.0.0.1', 'port': 11234, 'password': 'NONE'};
+    var cjdnsAdmin = {'addr': addr || '127.0.0.1', 'port': port || 11234, 'password': 'NONE'};
     nThen(function (waitFor) {
         Fs.readFile(process.env.HOME + '/.cjdnsadmin', waitFor(function (err, ret) {
-            if (err && err.code != 'ENOENT') { throw err; }
             if (!err) { cjdnsAdmin = JSON.parse(String(ret)); }
         }));
     }).nThen(function (waitFor) {

--- a/contrib/nodejs/cjdnsadmin/cjdnsadmin.js
+++ b/contrib/nodejs/cjdnsadmin/cjdnsadmin.js
@@ -218,7 +218,13 @@ var connectWithAdminInfo = module.exports.connectWithAdminInfo = function (callb
 };
 
 var connectAsAnon = module.exports.connectAsAnon = function (callback, addr, port) {
-    addr = addr || '127.0.0.1';
-    port = port || 11234;
-    connect(addr, port, null, callback);
+    var cjdnsAdmin = {'addr': '127.0.0.1', 'port': 11234, 'password': 'NONE'};
+    nThen(function (waitFor) {
+        Fs.readFile(process.env.HOME + '/.cjdnsadmin', waitFor(function (err, ret) {
+            if (err && err.code != 'ENOENT') { throw err; }
+            if (!err) { cjdnsAdmin = JSON.parse(String(ret)); }
+        }));
+    }).nThen(function (waitFor) {
+        connect(cjdnsAdmin.addr, cjdnsAdmin.port, null, callback);
+    });
 };

--- a/contrib/python/cjdnsadmin/adminTools.py
+++ b/contrib/python/cjdnsadmin/adminTools.py
@@ -11,11 +11,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import json
+
 from time import sleep
 
 def anonConnect(ip='127.0.0.1', port=11234):
     from cjdnsadmin import connect
-    return connect(ip, int(port), '')
+    path = os.path.expanduser('~/.cjdnsadmin')
+    try:
+        with open(path, 'r') as adminInfo:
+            data = json.load(adminInfo)
+        return connect(data['addr'], data['port'], '')
+    except IOError:
+        return connect(ip, int(port), '')
 
 def connect(ip='127.0.0.1', port=11234, password=''):
     from cjdnsadmin import connectWithAdminInfo


### PR DESCRIPTION
Python/Nodejs version admin api are using hardcode ip/port to do anonymous connect, the admin ip/port should be read from .cjdnsadmin as normal connect operation.