### PR TITLE
Add more nodes flag in RouterModule_getPeers response

### DIFF
--- a/dht/CJDHTConstants.h
+++ b/dht/CJDHTConstants.h
@@ -39,6 +39,9 @@ static String* const CJDHTConstants_TARGET = String_CONST_SO("tar");
 // Response with nodes. "n"
 static String* const CJDHTConstants_NODES = String_CONST_SO("n");
 
+// More peers available during Get (direct) peers query.
+static String* const CJDHTConstants_MORE_NODES = String_CONST_SO("mn");
+
 // Transaction id
 static String* const CJDHTConstants_TXID = String_CONST_SO("txid");
 

--- a/dht/dhtcore/RouterModule.c
+++ b/dht/dhtcore/RouterModule.c
@@ -268,6 +268,11 @@ static inline int sendNodes(struct NodeList* nodeList,
         struct Address addr;
         Bits_memcpyConst(&addr, &nodeList->nodes[i]->address, sizeof(struct Address));
 
+        if (i == 0 && (nodeList->size == RouterModule_K)) {
+            Dict_putInt(message->asDict, CJDHTConstants_MORE_NODES,
+                        addr.path, message->allocator);
+        }
+
         addr.path = NumberCompress_getLabelFor(addr.path, query->address->path);
 
         Address_serialize(&nodes->bytes[i * Address_SERIALIZED_SIZE], &addr);


### PR DESCRIPTION
Using more flag to get all peersNodes instead of random fetch.
Pros:
* Can get the full peer nodes lists from peer.
* Do not miss peer node(all peer nodes will be found than before random lookup)

Cons:
* huge peer nodes list cause more traffic than before, 30 child list need total 5 time request.
* Malformed response(always set the more flag) attack
* Incompatible with old protocol implementing 