### PR TITLE
NodeStore stuff

### DIFF
--- a/dht/Pathfinder.c
+++ b/dht/Pathfinder.c
@@ -143,7 +143,7 @@ static void onBestPathChange(void* vPathfinder, struct Node_Two* node)
     struct Pathfinder_pvt* pf = Identity_check((struct Pathfinder_pvt*) vPathfinder);
     struct Allocator* alloc = Allocator_child(pf->alloc);
     struct Message* msg = Message_new(0, 256, alloc);
-    Iface_CALL(sendNode, msg, &node->address, 0xffffffffu - Node_getReach(node), pf);
+    Iface_CALL(sendNode, msg, &node->address, Node_getCost(node), pf);
     Allocator_free(alloc);
 }
 

--- a/dht/dhtcore/Janitor.c
+++ b/dht/dhtcore/Janitor.c
@@ -649,8 +649,8 @@ static void maintanenceCycle(void* vcontext)
 
     struct Node_Two* n = NodeStore_getBest(janitor->nodeStore, addr.ip6.bytes);
 
-    // If the best next node doesn't exist or has 0 reach, run a local maintenance search.
-    if (n == NULL || Node_getReach(n) == 0) {
+    // If the best next node doesn't exist or has maximum cost, run a local maintenance search.
+    if (n == NULL || Node_getCost(n) == UINT64_MAX) {
         // or actually, don't
         //search(addr.ip6.bytes, janitor);
         //plugLargestKeyspaceHole(janitor, true);

--- a/dht/dhtcore/Janitor.c
+++ b/dht/dhtcore/Janitor.c
@@ -277,9 +277,9 @@ static void peersResponseCallback(struct RouterModule_Promise* promise,
         if (!Bits_memcmp(addresses->elems[i].key, from->key, 32)) { continue; }
 
         struct Node_Link* nl = NodeStore_linkForPath(janitor->nodeStore, addresses->elems[i].path);
-        if (!nl || Bits_memcmp(nl->child->address.ip6.bytes,
-                               addresses->elems[i].ip6.bytes,
-                               Address_SEARCH_TARGET_SIZE))
+        if (!nl || nl->linkCost == UINT32_MAX || Bits_memcmp(nl->child->address.ip6.bytes,
+                                                             addresses->elems[i].ip6.bytes,
+                                                             Address_SEARCH_TARGET_SIZE))
         {
             struct Node_Two* node = NodeStore_nodeForAddr(janitor->nodeStore,
                                                           addresses->elems[i].ip6.bytes);

--- a/dht/dhtcore/Node.c
+++ b/dht/dhtcore/Node.c
@@ -29,39 +29,39 @@ bool Node_isAncestorOf(struct Node_Two* ancestor, struct Node_Two* child)
     }
 }
 
-void Node_setReach(struct Node_Two* node, uint32_t newReach)
+void Node_setCost(struct Node_Two* node, uint64_t newCost)
 {
-    if (newReach) {
+    if (newCost != UINT64_MAX) {
         Assert_true(Node_getBestParent(node));
         Assert_true(node->address.path < UINT64_MAX);
     } else {
         Assert_true(!Node_getBestParent(node));
         Assert_true(node->address.path == UINT64_MAX);
     }
-    node->reach_pvt = newReach;
+    node->cost_pvt = newCost;
 }
 
-void Node_setParentReachAndPath(struct Node_Two* node,
-                                struct Node_Link* bestParent,
-                                uint32_t reach,
-                                uint64_t path)
+void Node_setParentCostAndPath(struct Node_Two* node,
+                               struct Node_Link* bestParent,
+                               uint64_t cost,
+                               uint64_t path)
 {
     if (bestParent) {
         Assert_true(bestParent->child == node);
-        Assert_true(reach);
+        Assert_true(cost != UINT64_MAX);
         Assert_true(path != UINT64_MAX);
         if (bestParent->parent == node) {
-            Assert_true(reach == UINT32_MAX);
+            Assert_true(cost == 0);
             Assert_true(path == 1);
         } else {
             Assert_true(!Node_isAncestorOf(node, bestParent->parent));
         }
     } else {
-        Assert_true(!reach);
+        Assert_true(cost == UINT64_MAX);
         Assert_true(path == UINT64_MAX);
     }
     node->bestParent_pvt = bestParent;
-    node->reach_pvt = reach;
+    node->cost_pvt = cost;
     node->address.path = path;
 }
 

--- a/dht/dhtcore/Node.h
+++ b/dht/dhtcore/Node.h
@@ -27,11 +27,10 @@ struct Node_Link;
 struct Node_Two
 {
     /**
-     * The reach of the node (how big/fast/close it is).
-     * Since reach is a fraction, the reach number represents a percentage where 0xFFFFFFFF = 100%
+     * The cost of the node (how small/slow/far it is).
      * DO NOT ALTER THIS OUTSIDE OF NODESTORE
      */
-    uint32_t reach_pvt;
+    uint32_t cost_pvt;
 
     /** This is used to mark/sweep nodes in getWorstNode(), it's meaningless otherwise. */
     uint32_t marked;
@@ -95,9 +94,9 @@ struct Node_Link
 
     /**
      * The quality of the link between parent and child,
-     * between 0xFFFFFFFF (perfect) and 0 (intolerable).
+     * between 0 (perfect) and 0xFFFFFFFF (intolerable).
      */
-    uint32_t linkState;
+    uint32_t linkCost;
 
     /** The time this link was last seen carrying traffic. (Currently limited to ping traffic.) */
     uint64_t timeLastSeen;
@@ -132,11 +131,11 @@ struct Node_Link
     Identity
 };
 
-static inline uint32_t Node_getReach(struct Node_Two* node)
+static inline uint64_t Node_getCost(struct Node_Two* node)
 {
-    return node->reach_pvt;
+    return node->cost_pvt;
 }
-void Node_setReach(struct Node_Two* node, uint32_t newReach);
+void Node_setCost(struct Node_Two* node, uint64_t newCost);
 
 static inline struct Node_Link* Node_getBestParent(struct Node_Two* node)
 {
@@ -145,9 +144,9 @@ static inline struct Node_Link* Node_getBestParent(struct Node_Two* node)
 
 bool Node_isAncestorOf(struct Node_Two* ancestor, struct Node_Two* child);
 
-void Node_setParentReachAndPath(struct Node_Two* node,
+void Node_setParentCostAndPath(struct Node_Two* node,
                                 struct Node_Link* bestParent,
-                                uint32_t reach,
+                                uint64_t cost,
                                 uint64_t path);
 
 bool Node_isOneHopLink(struct Node_Link* link);

--- a/dht/dhtcore/Node.h
+++ b/dht/dhtcore/Node.h
@@ -30,7 +30,7 @@ struct Node_Two
      * The cost of the node (how small/slow/far it is).
      * DO NOT ALTER THIS OUTSIDE OF NODESTORE
      */
-    uint32_t cost_pvt;
+    uint64_t cost_pvt;
 
     /** This is used to mark/sweep nodes in getWorstNode(), it's meaningless otherwise. */
     uint32_t marked;

--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -2013,6 +2013,7 @@ void NodeStore_pathTimeout(struct NodeStore* nodeStore, uint64_t path)
     struct NodeStore_pvt* store = Identity_check((struct NodeStore_pvt*)nodeStore);
 
     struct Node_Link* link = NodeStore_linkForPath(nodeStore, path);
+    if (!link) { return; }
     struct Node_Two* node = link->child;
 
     // TODO(cjd): What we really should be doing here is storing this link in a

--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -1128,6 +1128,11 @@ static struct Node_Link* discoverLinkC(struct NodeStore_pvt* store,
 
     check(store);
 
+    // FIXME(arceliar,cjd): This is still bad, but lets assume 1-hop links are great.
+    if (Node_isOneHopLink(parentLink)) {
+        handleLinkNews(parentLink, 0, store);
+    }
+
     return parentLink;
 }
 

--- a/dht/dhtcore/NodeStore.h
+++ b/dht/dhtcore/NodeStore.h
@@ -72,11 +72,10 @@ struct NodeStore* NodeStore_new(struct Address* myAddress,
  *
  * @param nodeStore the store
  * @param addr the address of the new node
- * @param reachDiff the amount to credit this node
  * @param scheme the encoding scheme used by this node.
  * @param encodingFormNumber the number of the smallest possible encoding form for to encoding
  *                           the interface number through which this message came.
- * @param reach the quality of the path to the new node
+ * @param milliseconds round-trip-time of the ping/getPeers/search that discovered this node.
  */
 struct Node_Link* NodeStore_discoverNode(struct NodeStore* nodeStore,
                                          struct Address* addr,
@@ -154,6 +153,7 @@ char* NodeStore_getRouteLabel_strerror(uint64_t returnVal);
 
 
 /**
+ * FIXME(arceliar): Documentation is out of date
  * Find the one best node using LinkStateNodeCollector. LinkStateNodeCollector prefers a
  * keyspace match (same address). It breaks ties by choosing the highest version node
  * (versions above it's own are considered the same as it's version). It breaks ties of the
@@ -196,7 +196,7 @@ struct NodeList* NodeStore_getClosestNodes(struct NodeStore* store,
                                            uint32_t versionOfRequestingNode,
                                            struct Allocator* allocator);
 
-// Used to update reach when a ping/search response comes in
+// Used to update cost when a ping/search response comes in
 void NodeStore_pathResponse(struct NodeStore* nodeStore, uint64_t path, uint64_t milliseconds);
 void NodeStore_pathTimeout(struct NodeStore* nodeStore, uint64_t path);
 

--- a/dht/dhtcore/NodeStore_admin.c
+++ b/dht/dhtcore/NodeStore_admin.c
@@ -60,7 +60,7 @@ static void dumpTable(Dict* args, void* vcontext, String* txid, struct Allocator
         AddrTools_printPath(path->bytes, nn->address.path);
         Dict_putString(nodeDict, String_CONST("path"), path, requestAlloc);
 
-        Dict_putInt(nodeDict, String_CONST("link"), Node_getReach(nn), requestAlloc);
+        Dict_putInt(nodeDict, String_CONST("link"), Node_getCost(nn), requestAlloc);
         Dict_putInt(nodeDict, String_CONST("version"), nn->address.protocolVersion, requestAlloc);
 
         Dict_putInt(nodeDict,
@@ -169,7 +169,7 @@ static void getLink(Dict* args, void* vcontext, String* txid, struct Allocator* 
                 String_new("inverseLinkEncodingFormNumber", alloc),
                 link->inverseLinkEncodingFormNumber,
                 alloc);
-    Dict_putInt(result, String_new("linkState", alloc), link->linkState, alloc);
+    Dict_putInt(result, String_new("linkCost", alloc), link->linkCost, alloc);
 
     Dict_putInt(result, String_new("isOneHop", alloc), Node_isOneHopLink(link), alloc);
 
@@ -229,7 +229,7 @@ static void nodeForAddr(Dict* args, void* vcontext, String* txid, struct Allocat
     uint32_t count = linkCount(node);
     Dict_putInt(result, String_new("linkCount", alloc), count, alloc);
 
-    Dict_putInt(result, String_new("reach", alloc), Node_getReach(node), alloc);
+    Dict_putInt(result, String_new("cost", alloc), Node_getCost(node), alloc);
 
     List* encScheme = EncodingScheme_asList(node->encodingScheme, alloc);
     Dict_putList(result, String_new("encodingScheme", alloc), encScheme, alloc);


### PR DESCRIPTION
Basically a rewrite of the path-finding and path-updating logic in the NodeStore. No more handleNews() stuff.

Instead of reach, we use cost. Cost *should* be defined in terms of latency or something sane like that, but lacking such info, it's just a reliability metric in this implementation.

Path cost and link cost are consistent (the cost of path A->B->C is equal to the cost of link A->B plus the cost of link B->C).