### PR TITLE
Add version for git, make it easy for debuging

### DIFF
--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -529,6 +529,7 @@ int main(int argc, char** argv)
         } else if ((CString_strcmp(argv[1], "--version") == 0)
             || (CString_strcmp(argv[1], "-v") == 0))
         {
+            printf("Cjdns version: %s\n", CJD_PACKAGE_VERSION);
             printf("Cjdns protocol version: %d\n", Version_CURRENT_PROTOCOL);
             return 0;
         } else if (CString_strcmp(argv[1], "--cleanconf") == 0) {

--- a/node_build/GetVersion.js
+++ b/node_build/GetVersion.js
@@ -1,0 +1,19 @@
+var nThen = require('nthen');
+var Spawn = require('child_process').spawn;
+
+var getversion = module.exports = function (callback) {
+    nThen(function (waitFor) {
+        var child = Spawn('git', ['describe', '--always', '--dirty']);
+        child.stdout.on('data', function(data) {
+            callback(data);
+        });
+        child.stderr.on('data', function(data) {
+            throw new Error("git error: " + data);
+        });
+        child.on('close', function(code) {
+        });
+        child.on('error', function(err) {
+            throw new Error("git error: " + err);
+        });
+    });
+};

--- a/node_build/builder.js
+++ b/node_build/builder.js
@@ -18,6 +18,7 @@ var Spawn = require('child_process').spawn;
 var nThen = require('nthen');
 var Crypto = require('crypto');
 var Semaphore = require('./Semaphore');
+var GetVersion = require('./GetVersion');
 
 /*
  * Why hello dear packager,
@@ -884,6 +885,7 @@ var configure = module.exports.configure = function (params, configFunc) {
 
     params.buildDir = params.buildDir || 'build_' + params.systemName;
 
+    var version;
     var state;
     var builder;
     var buildStage = function () {};
@@ -919,6 +921,13 @@ var configure = module.exports.configure = function (params, configFunc) {
 
     }).nThen(function (waitFor) {
 
+        GetVersion(waitFor(function(data) {
+            version = '' + data;
+            version = version.replace(/(\r\n|\n|\r)/gm, "");
+        }));
+
+    }).nThen(function (waitFor) {
+
         if (!state || !state.rebuildIfChanges) {
             // no state
             state = undefined;
@@ -938,11 +947,13 @@ var configure = module.exports.configure = function (params, configFunc) {
         // Do the configuration step
         if (state) {
             builder = mkBuilder(state);
+            builder.config.version = version;
             return;
         }
 
         state = getStatePrototype(params);
         builder = mkBuilder(state);
+        builder.config.version = version;
         probeCompiler(state, waitFor());
 
     }).nThen(function (waitFor) {

--- a/node_build/make.js
+++ b/node_build/make.js
@@ -55,6 +55,7 @@ Builder.configure({
         '-Wno-pointer-sign',
         '-pedantic',
         '-D', builder.config.systemName + '=1',
+        '-D', 'CJD_PACKAGE_VERSION="' + builder.config.version + '"',
         '-Wno-unused-parameter',
         '-fomit-frame-pointer',
 


### PR DESCRIPTION
Now `./cjdroute --version` will display the source code version, make it more friendly to debug segfault or other issues.