### PR TITLE
Make makekeys uses full IP print instead of short

### DIFF
--- a/contrib/c/makekeys.c
+++ b/contrib/c/makekeys.c
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
         if (AddressCalc_addressForPublicKey(ip, publicKey)) {
             Hex_encode(hexPrivateKey, 65, privateKey, 32);
             Base32_encode(publicKeyBase32, 53, publicKey, 32);
-            AddrTools_printShortIp(printedIp, ip);
+            AddrTools_printIp(printedIp, ip);
             printf("%s %s %s.k\n", hexPrivateKey, printedIp, publicKeyBase32);
             fflush(stdout);
         }


### PR DESCRIPTION
This PR is more proposition than fix.

Short IP printing is a bit tedious to pars in bash and others scripts so it would be great if it was replaced by normal long printing.

There shouldn't be any concerns about compatibility as both notations are valid IPv6.