### PR TITLE
Disable sysctl seed source if there is /proc/sys/ avalible

### DIFF
--- a/crypto/random/seed/LinuxRandomUuidSysctlRandomSeed.c
+++ b/crypto/random/seed/LinuxRandomUuidSysctlRandomSeed.c
@@ -12,12 +12,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#define _GNU_SOURCE
 #include "crypto/random/seed/LinuxRandomUuidSysctlRandomSeed.h"
 #include "util/Identity.h"
 #include "util/Bits.h"
 #include "util/Hex.h"
 
 #include <unistd.h>
+#include <sys/syscall.h>
 #include <sys/sysctl.h>
 
 static int getUUID(uint64_t output[2])
@@ -36,6 +38,17 @@ static int getUUID(uint64_t output[2])
 
 static int get(struct RandomSeed* randomSeed, uint64_t output[8])
 {
+
+#ifdef SYS_getrandom
+    // Try using getrandom instead sysctl as with systems with getrandom
+    // sysctl is probably alrady deprecated and possibly disabled.
+    Bits_memset(output, 0, 64); // Just make sure that it is zero all along.
+
+    long ret = syscall(SYS_getrandom, output, 64, 0);
+    if (ret == 64 && !Bits_isZero(output, 64)) {
+        return 0;
+    }
+#endif
     if (getUUID(output) || getUUID(output+2) || getUUID(output+4) || getUUID(output+6)) {
         return -1;
     }


### PR DESCRIPTION
As both of those are the same sources and sysctl has chance of logging kernel
warning it is better to disable deprecated one if new is available.

If you think there is better way of doing it please leave a comment and I will change it.