### PR TITLE
Fix git cjdns version

### DIFF
--- a/node_build/GetVersion.js
+++ b/node_build/GetVersion.js
@@ -3,7 +3,7 @@ var Spawn = require('child_process').spawn;
 
 var getversion = module.exports = function (callback) {
     nThen(function (waitFor) {
-        var child = Spawn('git', ['describe', '--always', '--dirty']);
+        var child = Spawn('git', ['describe', '--always', '--dirty', '--tags']);
         child.stdout.on('data', function(data) {
             callback(data);
         });


### PR DESCRIPTION
Without `--tags` git will use only annotated tags and the last one is v0.3