### PR TITLE
Using OP's udp auto fragment to send out large Peers nodes response

### DIFF
--- a/dht/DHTMessage.h
+++ b/dht/DHTMessage.h
@@ -21,7 +21,7 @@
  * Maximum number of bytes in a message.
  * Ethernet MTU is 1500 so it's hard to imagine much more.
  */
-#define DHTMessage_MAX_SIZE 1536
+#define DHTMessage_MAX_SIZE 65500
 
 
 /**

--- a/dht/dhtcore/Janitor.c
+++ b/dht/dhtcore/Janitor.c
@@ -445,22 +445,14 @@ static void getPeersMill(struct Janitor_pvt* janitor, struct Address* addr)
     // Therefore we will always ping the node which we believe to be at the end of the
     // path and if there is an error, we will flush the link rediscover the path later.
     // Don't use a random target if we actually know a useful one.
-    uint64_t targetLabel = Random_uint32(janitor->rand);
     struct Node_Link* nl = NodeStore_linkForPath(janitor->nodeStore, addr->path);
     if (nl) {
         addr = &nl->child->address;
-        struct Node_Link* link = NULL;
-        while ((link = NodeStore_nextLink(nl->child, link))) {
-            if (!Node_isOneHopLink(link) && link == Node_getBestParent(link->child)) {
-                targetLabel = nl->cannonicalLabel;
-                break;
-            }
-        }
     }
 
     struct RouterModule_Promise* rp =
         RouterModule_getPeers(addr,
-                              targetLabel,
+                              0,
                               0,
                               janitor->routerModule,
                               janitor->allocator);

--- a/dht/dhtcore/RouterModule.c
+++ b/dht/dhtcore/RouterModule.c
@@ -340,7 +340,8 @@ static inline int handleQuery(struct DHTMessage* message,
         targetPath = Endian_bigEndianToHost64(targetPath);
 
         nodeList =
-            NodeStore_getPeers(targetPath, RouterModule_K, message->allocator, module->nodeStore);
+            NodeStore_getPeers(targetPath, NumberCompress_INTERFACES,
+                    message->allocator, module->nodeStore);
 
     } else if (String_equals(queryType, CJDHTConstants_QUERY_NH)) {
         // get the target

--- a/interface/ETHInterface_darwin.c
+++ b/interface/ETHInterface_darwin.c
@@ -314,6 +314,7 @@ struct ETHInterface* ETHInterface_new(struct EventBase* eventBase,
     }
 
     Socket_makeNonBlocking(ctx->socket);
+    Socket_makeMTUFragment(ctx->socket);
 
     Event_socketRead(handleEvent, ctx, ctx->socket, eventBase, alloc, exHandler);
 

--- a/interface/ETHInterface_linux.c
+++ b/interface/ETHInterface_linux.c
@@ -282,6 +282,7 @@ struct ETHInterface* ETHInterface_new(struct EventBase* eventBase,
     }
 
     Socket_makeNonBlocking(ctx->socket);
+    Socket_makeMTUFragment(ctx->socket);
 
     Event_socketRead(handleEvent, ctx, ctx->socket, eventBase, alloc, exHandler);
 

--- a/util/events/libuv/UDPAddrIface.c
+++ b/util/events/libuv/UDPAddrIface.c
@@ -19,6 +19,7 @@
 #include "memory/Allocator.h"
 #include "util/events/libuv/EventBase_pvt.h"
 #include "util/platform/Sockaddr.h"
+#include "util/platform/Socket.h"
 #include "util/Assert.h"
 #include "util/Identity.h"
 #include "wire/Message.h"
@@ -121,7 +122,7 @@ static Iface_DEFUN incomingFromIface(struct Message* m, struct Iface* iface)
     };
 
     int ret = 0;
-    uv_udp_send(&req->uvReq, &context->uvHandle, buffers, 1,
+    ret = uv_udp_send(&req->uvReq, &context->uvHandle, buffers, 1,
                 (const struct sockaddr*)ss.nativeAddr, (uv_udp_send_cb)&sendComplete);
 
     if (ret) {
@@ -272,6 +273,8 @@ struct UDPAddrIface* UDPAddrIface_new(struct EventBase* eventBase,
         Except_throw(exHandler, "call to uv_udp_bind() failed [%s]",
                      uv_strerror(ret));
     }
+
+    Socket_makeMTUFragment(context->uvHandle.io_watcher.fd);
 
     ret = uv_udp_recv_start(&context->uvHandle, allocate, incoming);
     if (ret) {

--- a/util/events/libuv/UDPAddrIface.c
+++ b/util/events/libuv/UDPAddrIface.c
@@ -274,7 +274,11 @@ struct UDPAddrIface* UDPAddrIface_new(struct EventBase* eventBase,
                      uv_strerror(ret));
     }
 
-    Socket_makeMTUFragment(context->uvHandle.io_watcher.fd);
+    #ifdef win32
+        Socket_makeMTUFragment(context->uvHandle.socket);
+    #else
+        Socket_makeMTUFragment(context->uvHandle.io_watcher.fd);
+    #endif
 
     ret = uv_udp_recv_start(&context->uvHandle, allocate, incoming);
     if (ret) {

--- a/util/platform/Socket.c
+++ b/util/platform/Socket.c
@@ -13,11 +13,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "util/platform/Socket.h"
-#include <netinet/ip.h>
 
 #ifdef win32
     #include <winsock2.h>
+    #include <ws2tcpip.h>
 #else
+    #include <netinet/ip.h>
     #include <sys/socket.h>
 #endif
 #include <unistd.h>
@@ -63,7 +64,7 @@ int Socket_makeMTUFragment(int sock)
     int res = -1;
     #ifdef win32
         int flag = 0;
-        res = setsockopt(sock, SOL_IP, IP_DONTFRAGMENT, &flag, sizeof(flag));
+        res = setsockopt(sock, IPPROTO_IP, IP_DONTFRAGMENT, (char *)&flag, sizeof(flag));
     #endif
     #ifdef linux
         int flag = IP_PMTUDISC_DONT;
@@ -83,7 +84,7 @@ bool Socket_getMTUFragment(int sock)
     #ifdef win32
         int flag = 0;
         len = sizeof(flag);
-        if (!getsockopt(sock, SOL_IP, IP_DONTFRAGMENT, &flag, &len) &&
+        if (!getsockopt(sock, IPPROTO_IP, IP_DONTFRAGMENT, (char *)&flag, &len) &&
              flag) {
             res = true;
         }

--- a/util/platform/Socket.h
+++ b/util/platform/Socket.h
@@ -21,11 +21,14 @@
 Linker_require("util/platform/Socket.c")
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #define Socket int
 
 int Socket_makeNonBlocking(int sock);
 int Socket_makeReusable(int sock);
+int Socket_makeMTUFragment(int sock);
+bool Socket_getMTUFragment(int sock);
 
 int Socket_close(int sock);
 


### PR DESCRIPTION
Old DHT `getPeers` response only fetch 8 items for each request, if one node have a large peer lists(30 or more), peer node might miss hit by old implementing.
New DHT `getPeers` response will send out all peers nodes within one request, this will use OP's UDP auto fragment feature to send out the large peers nodes data.