### PR TITLE
Options to skip tests for fast development/hacking

### DIFF
--- a/cross-do
+++ b/cross-do
@@ -1,5 +1,39 @@
 #!/usr/bin/env bash
 
+function show_usage() {
+    echo "Usage:
+This script is the main build command, it handles dependencies and all,
+and creates the cjdroute binary program (and other tools).
+
+If you are a developer on Windows, you could use this command to have fast rebuilds:
+NO_TEST=1 ./do
+
+On e.g. Windows while build is a bit broken, try this advanced options to make rebuilds fast again:
+
+* NO_TEST=1 for e.g. on-Windows developers to have fast code rebuilds (rebuild changed files),
+even when unite tests are failing which usually forbids caching of build results (in state.json).
+
+* NO_CODESTYLE=1 this is just for quick hacking to ignore any codestyle errors
+and just build the hacked up code. Later fix your code before commiting it to git / PR!
+
+* option -v (must be the first option given) exits after showing platform information
+"
+}
+
+[[ "$1" == "-h" ]] \
+    && { show_usage; exit; }
+
+[[ -n "$PLATFORM" ]] \
+    || PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
+
+[[ -n "$MARCH" ]] \
+    || MARCH=$(uname -m | sed 's/i./x/g')
+
+echo "Running on PLATFORM=[$PLATFORM] MARCH=[$MARCH]"
+[[ "$PLATFORM" =~ cygwin.*|msys.* ]] \
+    && echo -e "\n\n\nOn Windows.\nIf you're a devel, see options (-h) for fast rebuilds!\n\n\n\n";
+[[ "$1" == "-v" ]] && exit;
+
 cross_log=cross_build_$$.log
 enabled_log=${LOG}
 
@@ -21,11 +55,11 @@ if [ "x$enabled_log" == "x1" ]; then
   echo Compiler CC: $CC > $cross_log
   echo Compiler CFLAGS: $CFLAGS >> $cross_log
   echo Compiler LDFLAGS: $LDFLAGS >> $cross_log
-  time ./do >> $cross_log 2>&1
+  time ./do "$@" >> $cross_log 2>&1
   mv cjdroute ${log_filename}_cjdroute
 else
   echo Compiler CC: $CC
   echo Compiler CFLAGS: $CFLAGS
   echo Compiler LDFLAGS: $LDFLAGS
-  time ./do
+  time ./do "$@"
 fi

--- a/do
+++ b/do
@@ -13,11 +13,42 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+
+function show_usage() {
+    echo "Usage:
+This script is the main build command, it handles dependencies and all,
+and creates the cjdroute binary program (and other tools).
+
+If you are a developer on Windows, you could use this command to have fast rebuilds:
+NO_TEST=1 ./do
+
+On e.g. Windows while build is a bit broken, try this advanced options to make rebuilds fast again:
+
+* NO_TEST=1 for e.g. on-Windows developers to have fast code rebuilds (rebuild changed files),
+even when unite tests are failing which usually forbids caching of build results (in state.json).
+
+* NO_CODESTYLE=1 this is just for quick hacking to ignore any codestyle errors
+and just build the hacked up code. Later fix your code before commiting it to git / PR!
+
+* option -v (must be the first option given) exits after showing platform information
+"
+}
+
+
+[[ "$1" == "-h" ]] \
+    && { show_usage; exit; }
+
 [[ -n "$PLATFORM" ]] \
     || PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
 
 [[ -n "$MARCH" ]] \
     || MARCH=$(uname -m | sed 's/i./x/g')
+
+echo "Running on PLATFORM=[$PLATFORM] MARCH=[$MARCH]"
+[[ "$PLATFORM" =~ cygwin.*|msys.* ]] \
+    && echo -e "\n\n\nOn Windows.\nIf you're a devel, see options (-h) for fast rebuilds!\n\n\n\n";
+[[ "$1" == "-v" ]] && exit;
+
 
 build_dir="build_$PLATFORM"
 node_min_ver='v0.8.15'

--- a/node_build/builder.js
+++ b/node_build/builder.js
@@ -1053,6 +1053,7 @@ var configure = module.exports.configure = function (params, configFunc) {
             return;
         }
 
+if (process.env['NO_CODESTYLE'] != '1') {
         debug("Checking codestyle");
 
         var sema = Semaphore.create(64);
@@ -1078,6 +1079,7 @@ var configure = module.exports.configure = function (params, configFunc) {
                 }));
             }));
         });
+}
 
     }).nThen(function (waitFor) {
 

--- a/node_build/make.js
+++ b/node_build/make.js
@@ -116,6 +116,10 @@ Builder.configure({
         }
     }
 
+    if (process.env['NO_TEST'] === '1') {
+        builder.config.cflags.push('-D', 'NOTEST=1');
+    }
+
     if (builder.config.compilerType.isClang) {
         // blows up when preprocessing before js preprocessor
         builder.config.cflags.push(

--- a/test/testcjdroute.c
+++ b/test/testcjdroute.c
@@ -41,6 +41,17 @@ static uint64_t runTest(Test test,
                         struct EventBase* base)
 {
     fprintf(stderr, "Running test %s", name);
+
+    #if NOTEST==1
+    {
+        fprintf(stderr,
+          "SKIPPING THE TEST (disabled by compilation options)! we are *NOT* Running test %s",
+           name);
+        uint64_t now = Time_hrtime();
+        return now;
+    }
+    #endif
+
     Assert_true(!test(argc, argv));
     uint64_t now = Time_hrtime();
     char* seventySpaces = "                                                                      ";


### PR DESCRIPTION
very usable for developers on e.g. Windows to have
fast code rebuilds that build only changed source
files, even while unit tests are failing.

See ./do -h for details

COMMENT: this is just for quick fixing to aid e.g. fixing the unit tests on windows.

Without this patch, on windows (mingw native build) now the project always rebuilds from scratch even when changing one .c file.
