### PR TITLE
Remove backtracing

### DIFF
--- a/util/Assert.c
+++ b/util/Assert.c
@@ -33,21 +33,6 @@ void Assert_failure(const char* format, ...)
     va_start(args, format);
     vfprintf(stderr, format, args);
     fflush(stderr);
-
-#if defined(__GLIBC__) && ! defined(__UCLIBC__)
-    void *array[20];
-    size_t size = backtrace(array, 20);
-    char **strings = backtrace_symbols(array, size);
-
-    fprintf(stderr, "Backtrace (%zd frames):\n", size);
-    for (size_t i = 0; i < size; i++)
-    {
-        fprintf(stderr, "  %s\n", strings[i]);
-    }
-    fflush(stderr);
-    free(strings);
-
-#endif
     abort();
     va_end(args);
 }


### PR DESCRIPTION
It is causing problems with seccomp
as it uses open call to load libgcc in runtime
which uses `open` syscall and we can't whitelist it.
(maybe if some is able to write string filter in BPF then we could load this lib)

See: https://ncry.pt/p/VnBn#XSqVCCXaoAk3puGiYwjQbPIRKFRwkQp0m_NMhdWyCGU