### PR TITLE
Remove backtracing

### DIFF
--- a/util/Assert.c
+++ b/util/Assert.c
@@ -19,10 +19,6 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
-#if defined(__GLIBC__) && ! defined(__UCLIBC__)
-#  include <execinfo.h>
-#endif
-
 Gcc_PRINTF(1, 2)
 void Assert_failure(const char* format, ...)
 {
@@ -33,21 +29,6 @@ void Assert_failure(const char* format, ...)
     va_start(args, format);
     vfprintf(stderr, format, args);
     fflush(stderr);
-
-#if defined(__GLIBC__) && ! defined(__UCLIBC__)
-    void *array[20];
-    size_t size = backtrace(array, 20);
-    char **strings = backtrace_symbols(array, size);
-
-    fprintf(stderr, "Backtrace (%zd frames):\n", size);
-    for (size_t i = 0; i < size; i++)
-    {
-        fprintf(stderr, "  %s\n", strings[i]);
-    }
-    fflush(stderr);
-    free(strings);
-
-#endif
     abort();
     va_end(args);
 }


### PR DESCRIPTION
It is causing problems with seccomp
as it uses open call to load libgcc in runtime
which uses `open` syscall and we can't whitelist it.