### PR TITLE
 Make cjdns addresses distinguishable from plain fc00::/8

### DIFF
--- a/crypto/AddressCalc.c
+++ b/crypto/AddressCalc.c
@@ -17,6 +17,11 @@
 
 #include <stdint.h>
 
+int AddressCalc_validAddress(const uint8_t address[16])
+{
+    return address[0] == 0xFC;
+}
+
 int AddressCalc_addressForPublicKey(uint8_t addressOut[16], const uint8_t key[32])
 {
     uint8_t hash[crypto_hash_sha512_BYTES];
@@ -25,10 +30,6 @@ int AddressCalc_addressForPublicKey(uint8_t addressOut[16], const uint8_t key[32
     if (addressOut) {
         Bits_memcpyConst(addressOut, hash, 16);
     }
-    return hash[0] == 0xFC;
+    return AddressCalc_validAddress(addressOut);
 }
 
-int AddressCalc_validAddress(const uint8_t address[16])
-{
-    return address[0] == 0xFC;
-}

--- a/crypto/AddressCalc.c
+++ b/crypto/AddressCalc.c
@@ -22,6 +22,13 @@ int AddressCalc_validAddress(const uint8_t address[16])
     return address[0] == 0xFC;
 }
 
+int AddressCalc_distinguishableAddress(const uint8_t address[16])
+{
+    uint8_t hash[crypto_hash_sha512_BYTES];
+    crypto_hash_sha512(hash, address, 16);
+    return AddressCalc_validAddress(address) && (hash[0] == 0xCC);
+}
+
 int AddressCalc_addressForPublicKey(uint8_t addressOut[16], const uint8_t key[32])
 {
     uint8_t hash[crypto_hash_sha512_BYTES];
@@ -30,6 +37,6 @@ int AddressCalc_addressForPublicKey(uint8_t addressOut[16], const uint8_t key[32
     if (addressOut) {
         Bits_memcpyConst(addressOut, hash, 16);
     }
-    return AddressCalc_validAddress(addressOut);
+    return AddressCalc_distinguishableAddress(addressOut);
 }
 

--- a/crypto/AddressCalc.h
+++ b/crypto/AddressCalc.h
@@ -36,4 +36,11 @@ bool AddressCalc_addressForPublicKey(uint8_t addressOut[16], const uint8_t key[3
  */
 bool AddressCalc_validAddress(const uint8_t address[16]);
 
+/**
+ * Check if an address is cjdns-specific given the IPv6
+ *
+ * @return true if the IPv6 is a distinguishable cjdns address.
+ */
+bool AddressCalc_distinguishableAddress(const uint8_t address[16]);
+
 #endif

--- a/net/SessionManager.c
+++ b/net/SessionManager.c
@@ -261,8 +261,9 @@ static Iface_DEFUN incomingFromSwitchIf(struct Message* msg, struct Iface* iface
         uint8_t* herKey = caHeader->handshake.publicKey;
         uint8_t ip6[16];
         // a packet which claims to be "from us" causes problems
-        if (!AddressCalc_addressForPublicKey(ip6, herKey)) {
-            Log_debug(sm->log, "DROP Handshake with non-fc key");
+        AddressCalc_addressForPublicKey(ip6, herKey);
+        if (!AddressCalc_validAddress(ip6)) {
+            Log_debug(sm->log, "DROP Handshake with non-cjdns key");
             return NULL;
         }
 


### PR DESCRIPTION
A lot of software treats fc00::/8 addresses as not globally accessible and blocks them. In case of Hyperboria it is not true.
So this is my variant of making addresses that are cjdns-specific so that software could allow cjdns and block plain fc00::/8:
> It calculates hash of 16-byte `fc00::/8` address and test if it is something "specical". In this case it's just limited with one byte (`0xCC`). Maybe it's too likely to have a match from ICANN space and it should be limited even more (too much work? less secure? There should be some trade-off).

P.S.  I does more bruteforce work. I'm looking forward faster and happier hash function. For me it looks like BLAKE2 is the best choice for that: it's faster that SHA-2, personalizable (an attacker have to bruteforce cjdns-specific BLAKE2), flexible digest size (useful for usage in addresses directly without trimming).

Depends on the commit from #883.