### PR TITLE
Using secure Siphash instead of old unsecure hash func

### DIFF
--- a/admin/Admin.c
+++ b/admin/Admin.c
@@ -63,9 +63,10 @@ struct MapValue
 #define Map_KEY_TYPE struct Sockaddr*
 #define Map_VALUE_TYPE struct MapValue*
 #include "util/Map.h"
-static inline uint32_t Map_LastMessageTimeByAddr_hash(struct Sockaddr** key)
+static inline uint64_t Map_LastMessageTimeByAddr_hash(struct Sockaddr** key,
+                                                      struct Map_LastMessageTimeByAddr* map)
 {
-    return Sockaddr_hash(*key);
+    return Sockaddr_hash(*key, map);
 }
 static inline int Map_LastMessageTimeByAddr_compare(struct Sockaddr** keyA, struct Sockaddr** keyB)
 {

--- a/contrib/c/sybilsim.c
+++ b/contrib/c/sybilsim.c
@@ -94,9 +94,9 @@ static inline int Map_OfNodes_compare(String** a, String** b)
 {
     return String_compare(*a, *b);
 }
-static inline uint32_t Map_OfNodes_hash(String** a)
+static inline uint64_t Map_OfNodes_hash(String** a, struct Map_OfNodes* map)
 {
-    return Hash_compute(a[0]->bytes, a[0]->len);
+    return Hash_compute(a[0]->bytes, a[0]->len, map->secretKey);
 }
 
 struct Context

--- a/net/InterfaceController.c
+++ b/net/InterfaceController.c
@@ -68,9 +68,10 @@
 #define Map_USE_HASH
 #define Map_USE_COMPARATOR
 #include "util/Map.h"
-static inline uint32_t Map_EndpointsBySockaddr_hash(struct Sockaddr** key)
+static inline uint64_t Map_EndpointsBySockaddr_hash(struct Sockaddr** key,
+                                                    struct Map_EndpointsBySockaddr* map)
 {
-    return Sockaddr_hash(*key);
+    return Sockaddr_hash(*key, map);
 }
 static inline int Map_EndpointsBySockaddr_compare(struct Sockaddr** keyA, struct Sockaddr** keyB)
 {

--- a/util/Hash.h
+++ b/util/Hash.h
@@ -15,16 +15,100 @@
 #ifndef Hash_H
 #define Hash_H
 
-#include <stdint.h>
+/*
+ * SipHash is a family of pseudorandom functions (a.k.a. keyed hash functions)
+ * optimized for speed on short messages.
+ *
+ * Target applications include network traffic authentication and defense against
+ * hash-flooding DoS attacks.
+ *
+ * Solution inspired by code from:
+ *     Jean-Philippe Aumasson (https://131002.net/siphash/siphash24.c)
+ * */
 
-/** The DJB2a hash (equivilant to DJB2 but using XOR instead of +) */
-static uint32_t Hash_compute(uint8_t* str, int length)
+#include <stdint.h>
+typedef uint64_t u64;
+typedef uint32_t u32;
+typedef uint8_t   u8;
+
+#define Hash_ROTL(x,b) (u64)( ((x) << (b)) | ( (x) >> (64 - (b))) )
+
+#define Hash_U8TO64_LE(p) \
+    (((u64)((p)[0])      ) | \
+     ((u64)((p)[1]) <<  8) | \
+     ((u64)((p)[2]) << 16) | \
+     ((u64)((p)[3]) << 24) | \
+     ((u64)((p)[4]) << 32) | \
+     ((u64)((p)[5]) << 40) | \
+     ((u64)((p)[6]) << 48) | \
+     ((u64)((p)[7]) << 56))
+
+#define Hash_SIPROUND            \
+    do {              \
+        v0 += v1; v1=Hash_ROTL(v1,13); v1 ^= v0; v0=Hash_ROTL(v0,32); \
+        v2 += v3; v3=Hash_ROTL(v3,16); v3 ^= v2;                      \
+        v0 += v3; v3=Hash_ROTL(v3,21); v3 ^= v0;                      \
+        v2 += v1; v1=Hash_ROTL(v1,17); v1 ^= v2; v2=Hash_ROTL(v2,32); \
+    } while (0);
+
+/* SipHash-2-4 */
+static uint64_t Hash_compute(const uint8_t* in, int length, uint8_t key[16])
 {
-    uint32_t hash = 5381;
-    for (int i = 0; i < length; i++) {
-        hash = ((hash << 5) + hash) ^ str[i];
+    /* "somepseudorandomlygeneratedbytes" */
+    u64 v0 = 0x736f6d6570736575ULL;
+    u64 v1 = 0x646f72616e646f6dULL;
+    u64 v2 = 0x6c7967656e657261ULL;
+    u64 v3 = 0x7465646279746573ULL;
+    u64 b;
+    u64 k0 = Hash_U8TO64_LE( key );
+    u64 k1 = Hash_U8TO64_LE( key + 8 );
+    u64 m;
+    const u8 *end = in + length - ( length % sizeof( u64 ) );
+    const int left = length & 7;
+    b = ( ( u64 )length) << 56;
+    v3 ^= k1;
+    v2 ^= k0;
+    v1 ^= k1;
+    v0 ^= k0;
+
+    for ( ; in != end; in += 8 ) {
+        m = Hash_U8TO64_LE( in );
+        v3 ^= m;
+        Hash_SIPROUND;
+        Hash_SIPROUND;
+        v0 ^= m;
     }
-    return hash;
+
+    switch( left )
+    {
+        case 7: b |= ( ( u64 )in[ 6] )  << 48;
+
+        case 6: b |= ( ( u64 )in[ 5] )  << 40;
+
+        case 5: b |= ( ( u64 )in[ 4] )  << 32;
+
+        case 4: b |= ( ( u64 )in[ 3] )  << 24;
+
+        case 3: b |= ( ( u64 )in[ 2] )  << 16;
+
+        case 2: b |= ( ( u64 )in[ 1] )  <<  8;
+
+        case 1: b |= ( ( u64 )in[ 0] ); break;
+
+        case 0: break;
+    }
+
+    v3 ^= b;
+    Hash_SIPROUND;
+    Hash_SIPROUND;
+    v0 ^= b;
+    v2 ^= 0xff;
+    Hash_SIPROUND;
+    Hash_SIPROUND;
+    Hash_SIPROUND;
+    Hash_SIPROUND;
+    b = v0 ^ v1 ^ v2  ^ v3;
+    return b;
 }
 
 #endif

--- a/util/Hash.h
+++ b/util/Hash.h
@@ -27,21 +27,18 @@
  * */
 
 #include <stdint.h>
-typedef uint64_t u64;
-typedef uint32_t u32;
-typedef uint8_t   u8;
 
-#define Hash_ROTL(x,b) (u64)( ((x) << (b)) | ( (x) >> (64 - (b))) )
+#define Hash_ROTL(x,b) (uint64_t)( ((x) << (b)) | ( (x) >> (64 - (b))) )
 
 #define Hash_U8TO64_LE(p) \
-    (((u64)((p)[0])      ) | \
-     ((u64)((p)[1]) <<  8) | \
-     ((u64)((p)[2]) << 16) | \
-     ((u64)((p)[3]) << 24) | \
-     ((u64)((p)[4]) << 32) | \
-     ((u64)((p)[5]) << 40) | \
-     ((u64)((p)[6]) << 48) | \
-     ((u64)((p)[7]) << 56))
+    (((uint64_t)((p)[0])      ) | \
+     ((uint64_t)((p)[1]) <<  8) | \
+     ((uint64_t)((p)[2]) << 16) | \
+     ((uint64_t)((p)[3]) << 24) | \
+     ((uint64_t)((p)[4]) << 32) | \
+     ((uint64_t)((p)[5]) << 40) | \
+     ((uint64_t)((p)[6]) << 48) | \
+     ((uint64_t)((p)[7]) << 56))
 
 #define Hash_SIPROUND            \
     do {              \
@@ -55,17 +52,17 @@ typedef uint8_t   u8;
 static uint64_t Hash_compute(const uint8_t* in, int length, uint8_t key[16])
 {
     /* "somepseudorandomlygeneratedbytes" */
-    u64 v0 = 0x736f6d6570736575ULL;
-    u64 v1 = 0x646f72616e646f6dULL;
-    u64 v2 = 0x6c7967656e657261ULL;
-    u64 v3 = 0x7465646279746573ULL;
-    u64 b;
-    u64 k0 = Hash_U8TO64_LE( key );
-    u64 k1 = Hash_U8TO64_LE( key + 8 );
-    u64 m;
-    const u8 *end = in + length - ( length % sizeof( u64 ) );
+    uint64_t v0 = 0x736f6d6570736575ULL;
+    uint64_t v1 = 0x646f72616e646f6dULL;
+    uint64_t v2 = 0x6c7967656e657261ULL;
+    uint64_t v3 = 0x7465646279746573ULL;
+    uint64_t b;
+    uint64_t k0 = Hash_U8TO64_LE( key );
+    uint64_t k1 = Hash_U8TO64_LE( key + 8 );
+    uint64_t m;
+    const uint8_t* end = in + length - ( length % sizeof( uint64_t ) );
     const int left = length & 7;
-    b = ( ( u64 )length) << 56;
+    b = ( ( uint64_t )length) << 56;
     v3 ^= k1;
     v2 ^= k0;
     v1 ^= k1;
@@ -81,19 +78,19 @@ static uint64_t Hash_compute(const uint8_t* in, int length, uint8_t key[16])
 
     switch( left )
     {
-        case 7: b |= ( ( u64 )in[ 6] )  << 48;
+        case 7: b |= ( ( uint64_t )in[ 6] )  << 48;
 
-        case 6: b |= ( ( u64 )in[ 5] )  << 40;
+        case 6: b |= ( ( uint64_t )in[ 5] )  << 40;
 
-        case 5: b |= ( ( u64 )in[ 4] )  << 32;
+        case 5: b |= ( ( uint64_t )in[ 4] )  << 32;
 
-        case 4: b |= ( ( u64 )in[ 3] )  << 24;
+        case 4: b |= ( ( uint64_t )in[ 3] )  << 24;
 
-        case 3: b |= ( ( u64 )in[ 2] )  << 16;
+        case 3: b |= ( ( uint64_t )in[ 2] )  << 16;
 
-        case 2: b |= ( ( u64 )in[ 1] )  <<  8;
+        case 2: b |= ( ( uint64_t )in[ 1] )  <<  8;
 
-        case 1: b |= ( ( u64 )in[ 0] ); break;
+        case 1: b |= ( ( uint64_t )in[ 0] ); break;
 
         case 0: break;
     }

--- a/util/events/libuv/FakeNetwork.c
+++ b/util/events/libuv/FakeNetwork.c
@@ -27,9 +27,10 @@
 #define Map_KEY_TYPE struct Sockaddr*
 #define Map_VALUE_TYPE struct FakeNetwork_UDPIface_pvt*
 #include "util/Map.h"
-static inline uint32_t Map_OfIfaces_hash(struct Sockaddr** key)
+static inline uint64_t Map_OfIfaces_hash(struct Sockaddr** key,
+                                         struct Map_OfIfaces* map)
 {
-    return Sockaddr_hash(*key);
+    return Sockaddr_hash(*key, map);
 }
 static inline int Map_OfIfaces_compare(struct Sockaddr** keyA, struct Sockaddr** keyB)
 {

--- a/util/platform/Sockaddr.c
+++ b/util/platform/Sockaddr.c
@@ -311,9 +311,9 @@ struct Sockaddr* Sockaddr_fromName(char* name, struct Allocator* alloc)
     return NULL;
 }
 
-uint32_t Sockaddr_hash(const struct Sockaddr* addr)
+uint32_t Sockaddr_hash(const struct Sockaddr* addr, void* map)
 {
-    return Hash_compute((uint8_t*)addr, addr->addrLen);
+    return Hash_compute((uint8_t*)addr, addr->addrLen, map);
 }
 
 int Sockaddr_compare(const struct Sockaddr* a, const struct Sockaddr* b)

--- a/util/platform/Sockaddr.h
+++ b/util/platform/Sockaddr.h
@@ -139,7 +139,7 @@ void Sockaddr_normalizeNative(void* nativeSockaddr);
 /**
  * Get a hash for hashtable lookup.
  */
-uint32_t Sockaddr_hash(const struct Sockaddr* addr);
+uint32_t Sockaddr_hash(const struct Sockaddr* addr, void* map);
 
 /**
  * Compare two sockaddrs for sorting, comparison does not put them in any specific order.


### PR DESCRIPTION
SipHash is an Add-Rotate-Xor based family of pseudorandom functions created by Jean-Philippe Aumasson and Daniel J. Bernstein in 2012. SipHash target applications include network traffic authentication and defense against hash-flooding DoS attacks.