### PR TITLE
Introduce InterfaceController_resetPeering

### DIFF
--- a/net/InterfaceController.c
+++ b/net/InterfaceController.c
@@ -936,6 +936,39 @@ int InterfaceController_getPeerStats(struct InterfaceController* ifController,
     return count;
 }
 
+int InterfaceController_resetPeer(struct InterfaceController* ifController,
+                                  uint8_t herPublicKey[32])
+{
+    struct InterfaceController_pvt* ic =
+        Identity_check((struct InterfaceController_pvt*) ifController);
+
+    for (int j = 0; j < ic->icis->length; j++) {
+        struct InterfaceController_Iface_pvt* ici = ArrayList_OfIfaces_get(ic->icis, j);
+        for (int i = 0; i < (int)ici->peerMap.count; i++) {
+            struct Peer* peer = ici->peerMap.values[i];
+            if (!Bits_memcmp(herPublicKey, peer->caSession->herPublicKey, 32)) {
+                CryptoAuth_reset(peer->caSession);
+                return 0;
+            }
+        }
+    }
+    return InterfaceController_disconnectPeer_NOTFOUND;
+}
+
+void InterfaceController_resetPeering(struct InterfaceController* ifController)
+{
+    struct InterfaceController_pvt* ic =
+        Identity_check((struct InterfaceController_pvt*) ifController);
+
+    for (int j = 0; j < ic->icis->length; j++) {
+        struct InterfaceController_Iface_pvt* ici = ArrayList_OfIfaces_get(ic->icis, j);
+        for (int i = 0; i < (int)ici->peerMap.count; i++) {
+            struct Peer* peer = ici->peerMap.values[i];
+            CryptoAuth_reset(peer->caSession);
+        }
+    }
+}
+
 int InterfaceController_disconnectPeer(struct InterfaceController* ifController,
                                        uint8_t herPublicKey[32])
 {

--- a/net/InterfaceController.c
+++ b/net/InterfaceController.c
@@ -936,8 +936,8 @@ int InterfaceController_getPeerStats(struct InterfaceController* ifController,
     return count;
 }
 
-int InterfaceController_resetPeer(struct InterfaceController* ifController,
-                                  uint8_t herPublicKey[32])
+void InterfaceController_resetPeering(struct InterfaceController* ifController,
+                                      uint8_t herPublicKey[32])
 {
     struct InterfaceController_pvt* ic =
         Identity_check((struct InterfaceController_pvt*) ifController);
@@ -946,25 +946,9 @@ int InterfaceController_resetPeer(struct InterfaceController* ifController,
         struct InterfaceController_Iface_pvt* ici = ArrayList_OfIfaces_get(ic->icis, j);
         for (int i = 0; i < (int)ici->peerMap.count; i++) {
             struct Peer* peer = ici->peerMap.values[i];
-            if (!Bits_memcmp(herPublicKey, peer->caSession->herPublicKey, 32)) {
+            if (!herPublicKey || !Bits_memcmp(herPublicKey, peer->caSession->herPublicKey, 32)) {
                 CryptoAuth_reset(peer->caSession);
-                return 0;
             }
-        }
-    }
-    return InterfaceController_disconnectPeer_NOTFOUND;
-}
-
-void InterfaceController_resetPeering(struct InterfaceController* ifController)
-{
-    struct InterfaceController_pvt* ic =
-        Identity_check((struct InterfaceController_pvt*) ifController);
-
-    for (int j = 0; j < ic->icis->length; j++) {
-        struct InterfaceController_Iface_pvt* ici = ArrayList_OfIfaces_get(ic->icis, j);
-        for (int i = 0; i < (int)ici->peerMap.count; i++) {
-            struct Peer* peer = ici->peerMap.values[i];
-            CryptoAuth_reset(peer->caSession);
         }
     }
 }

--- a/net/InterfaceController.h
+++ b/net/InterfaceController.h
@@ -163,6 +163,11 @@ int InterfaceController_beaconState(struct InterfaceController* ifc,
                                     int interfaceNumber,
                                     int newState);
 
+int InterfaceController_resetPeer(struct InterfaceController* ifController,
+                                  uint8_t herPublicKey[32]);
+
+void InterfaceController_resetPeering(struct InterfaceController* ifController);
+
 /**
  * Disconnect a previously registered peer.
  *

--- a/net/InterfaceController.h
+++ b/net/InterfaceController.h
@@ -163,10 +163,8 @@ int InterfaceController_beaconState(struct InterfaceController* ifc,
                                     int interfaceNumber,
                                     int newState);
 
-int InterfaceController_resetPeer(struct InterfaceController* ifController,
-                                  uint8_t herPublicKey[32]);
-
-void InterfaceController_resetPeering(struct InterfaceController* ifController);
+void InterfaceController_resetPeering(struct InterfaceController* ifController,
+                                      uint8_t herPublicKey[32]);
 
 /**
  * Disconnect a previously registered peer.

--- a/net/InterfaceController.h
+++ b/net/InterfaceController.h
@@ -178,7 +178,7 @@ void InterfaceController_resetPeering(struct InterfaceController* ifController,
  *
  * @param ic the if controller
  * @param herPublicKey the public key of the foreign node
- * @retrun 0 if all goes well.
+ * @return 0 if all goes well.
  *         InterfaceController_disconnectPeer_NOTFOUND if no peer with herPublicKey is found.
  */
 #define InterfaceController_disconnectPeer_NOTFOUND -1

--- a/net/InterfaceController.h
+++ b/net/InterfaceController.h
@@ -163,6 +163,13 @@ int InterfaceController_beaconState(struct InterfaceController* ifc,
                                     int interfaceNumber,
                                     int newState);
 
+/**
+ * CryptoAuth_reset() a peer to reestablish the connection.
+ *
+ * @param ic the if controller
+ * @param herPublicKey the public key of the foreign node or NULL for all peers
+ * @return void
+ */
 void InterfaceController_resetPeering(struct InterfaceController* ifController,
                                       uint8_t herPublicKey[32]);
 

--- a/net/InterfaceController_admin.c
+++ b/net/InterfaceController_admin.c
@@ -144,6 +144,46 @@ static void adminDisconnectPeer(Dict* args,
 
     Admin_sendMessage(response, txid, context->admin);
 }
+
+static void adminResetPeering(Dict* args,
+                              void* vcontext,
+                              String* txid,
+                              struct Allocator* requestAlloc)
+{
+    struct Context* context = Identity_check((struct Context*)vcontext);
+    String* pubkeyString = Dict_getString(args, String_CONST("pubkey"));
+
+    int error = 0;
+    char* errorMsg = NULL;
+
+    if (pubkeyString) {
+        // parse the key
+        uint8_t pubkey[32];
+        uint8_t addr[16];
+        error = Key_parse(pubkeyString, pubkey, addr);
+
+        if (error) {
+            errorMsg = "bad key";
+        } else {
+            error = InterfaceController_resetPeer(context->ic, pubkey);
+            if (error) {
+                errorMsg = "no peer found for that key";
+            }
+        }
+    } else {
+        // reset all
+        InterfaceController_resetPeering(context->ic);
+    }
+
+    Dict* response = Dict_new(requestAlloc);
+    Dict_putInt(response, String_CONST("success"), error ? 0 : 1, requestAlloc);
+    if (error) {
+        Dict_putString(response, String_CONST("error"), String_CONST(errorMsg), requestAlloc);
+    }
+
+    Admin_sendMessage(response, txid, context->admin);
+}
+
 /*
 static resetSession(Dict* args, void* vcontext, String* txid, struct Allocator* requestAlloc)
 {
@@ -190,6 +230,11 @@ void InterfaceController_admin_register(struct InterfaceController* ic,
     Admin_registerFunction("InterfaceController_peerStats", adminPeerStats, ctx, false,
         ((struct Admin_FunctionArg[]) {
             { .name = "page", .required = 0, .type = "Int" }
+        }), admin);
+
+    Admin_registerFunction("InterfaceController_resetPeering", adminResetPeering, ctx, true,
+        ((struct Admin_FunctionArg[]) {
+            { .name = "pubkey", .required = 0, .type = "String" }
         }), admin);
 
     Admin_registerFunction("InterfaceController_disconnectPeer", adminDisconnectPeer, ctx, true,

--- a/net/InterfaceController_admin.c
+++ b/net/InterfaceController_admin.c
@@ -165,14 +165,11 @@ static void adminResetPeering(Dict* args,
         if (error) {
             errorMsg = "bad key";
         } else {
-            error = InterfaceController_resetPeer(context->ic, pubkey);
-            if (error) {
-                errorMsg = "no peer found for that key";
-            }
+            InterfaceController_resetPeering(context->ic, pubkey);
         }
     } else {
         // reset all
-        InterfaceController_resetPeering(context->ic);
+        InterfaceController_resetPeering(context->ic, NULL);
     }
 
     Dict* response = Dict_new(requestAlloc);


### PR DESCRIPTION
This change allows you to reset your connections in case your public
ICANN ip address has changed.

This calls CryptoAuth_reset on all peers, which reestablishes the
connections.

    tools/cexec 'InterfaceController_resetPeering()'

Your peers then detect there's a more recent connection and the old,
broken one is replaced, so you don't have to wait until they are timed
out by your local cjdroute. You don't lose the routes you've already
learned, so your connections on fc00::/8 should be responsive instantly.

To reset one specific peer, run

    tools/cexec 'InterfaceController_resetPeering("pubkey.k")'

You can add this as dispatcher for NetworkManager so it automatically
resets if you connect to another network.