### PR TITLE
Implement QSort

### DIFF
--- a/util/ArrayList.c
+++ b/util/ArrayList.c
@@ -15,6 +15,7 @@
 #define ArrayList_NOCREATE
 #include "util/ArrayList.h"
 #include "util/Bits.h"
+#include "util/QSort.h"
 
 #include <stddef.h>
 #include <stdlib.h>
@@ -82,7 +83,7 @@ int ArrayList_put(struct ArrayList* vlist, int number, void* val)
 void ArrayList_sort(struct ArrayList* vlist, int (* compare)(const void* a, const void* b))
 {
     struct ArrayList_pvt* list = Identity_check((struct ArrayList_pvt*) vlist);
-    qsort(list->elements, list->length, sizeof(char*), compare);
+    QSort(list->elements, list->length, sizeof(char*), compare);
 }
 
 void* ArrayList_clone(struct ArrayList* vlist, struct Allocator* alloc)

--- a/util/Order.c
+++ b/util/Order.c
@@ -13,10 +13,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "util/Order.h"
-
-#include <stdlib.h>
+#include "util/QSort.h"
 
 void Order_qsort(void* base, size_t num, size_t size, Order_Comparator compare)
 {
-    qsort(base, num, size, compare);
+    QSort(base, num, size, compare);
 }

--- a/util/QSort.h
+++ b/util/QSort.h
@@ -1,0 +1,57 @@
+/* vim: set expandtab ts=4 sw=4: */
+/*
+ * You may redistribute this program and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef QSort_H
+#define QSort_H
+#include "util/Bits.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+static inline void QSort(void* base, size_t members, size_t size,
+                         int (*compar) (const void *, const void *))
+{
+    size_t i, j;
+    size_t gap = members;
+    uintptr_t p1, p2;
+    bool worked;
+
+    if (!members) {
+        return;
+    }
+
+    do {
+        gap = (gap * 10) / 13;
+        if (gap == 9 || gap == 10) {
+            gap = 11;
+        } else if (gap < 1) {
+            gap = 1;
+        }
+        worked = false;
+
+        for (i = 0, p1 = (uintptr_t) base; i < members - gap; i++, p1 += size) {
+            j = i + gap;
+            p2 = (uintptr_t) base + j * size;
+            if (compar((void *) p1, (void *) p2) > 0) {
+                uint8_t tmp[size];
+                Bits_memcpy(tmp, (void *) p1, size);
+                Bits_memcpy((void *) p1, (void *) p2, size);
+                Bits_memcpy((void *) p2, tmp, size);
+                worked = true;
+            }
+        }
+    } while (gap > 1 || worked);
+}
+
+#endif

--- a/util/test/QSort_test.c
+++ b/util/test/QSort_test.c
@@ -1,0 +1,39 @@
+/* vim: set expandtab ts=4 sw=4: */
+/*
+ * You may redistribute this program and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "util/Assert.h"
+#include "util/QSort.h"
+
+static int compare(const void* a, const void* b)
+{
+    return (*(int *) a - *(int *) b);
+}
+
+int main()
+{
+    int values[] = { 40, 10, 100, 90, 20, 25, -15, 30, -225};
+
+    QSort(values, sizeof(values) / sizeof(int), sizeof(int), compare);
+
+    int last = values[0];
+    for (size_t i = 1; i < sizeof(values) / sizeof(int); i++) {
+        Assert_true(last <= values[i]);
+        last = values[i];
+    }
+    // Should not crash
+    QSort(values, 0, sizeof(int), compare);
+
+    return 0;
+}


### PR DESCRIPTION
Due to _issues_ with glibc's `qsort` we have to use our own.

It is really comb sort but this does not matter that much.

glibc sometimes feels need to call `open` during sort, `open` is blocked syscall in cjdns.
https://gist.github.com/Kubuxu/237a425b1b7ee27eabe6