### PR TITLE
Setuid_linux: Use version 3 of the capabilities

### DIFF
--- a/util/Setuid_linux.c
+++ b/util/Setuid_linux.c
@@ -52,7 +52,7 @@ void Setuid_preSetuid(struct Allocator* alloc, struct Except* eh)
     cap_user_header_t hdr = Allocator_calloc(alloc, sizeof(*hdr), 1);
     cap_user_data_t data = Allocator_calloc(alloc, sizeof(*data), 1);
 
-    hdr->version = _LINUX_CAPABILITY_VERSION;
+    hdr->version = _LINUX_CAPABILITY_VERSION_3;
     hdr->pid = 0;
     if (capGet(hdr, data)) {
         Except_throw(eh, "Error getting capabilities: [errno:%d (%s)]", errno, strerror(errno));
@@ -75,7 +75,7 @@ void Setuid_postSetuid(struct Allocator* alloc, struct Except* eh)
     cap_user_header_t hdr = Allocator_calloc(alloc, sizeof(*hdr), 1);
     cap_user_data_t data = Allocator_calloc(alloc, sizeof(*data), 1);
 
-    hdr->version = _LINUX_CAPABILITY_VERSION;
+    hdr->version = _LINUX_CAPABILITY_VERSION_3;
     hdr->pid = 0;
     if (capGet(hdr, data)) {
         Except_throw(eh, "Error getting capabilities (post-setuid): [errno:%d (%s)]",

--- a/util/Setuid_linux.c
+++ b/util/Setuid_linux.c
@@ -50,7 +50,7 @@ static inline int capGet(cap_user_header_t hdr, cap_user_data_t data)
 void Setuid_preSetuid(struct Allocator* alloc, struct Except* eh)
 {
     cap_user_header_t hdr = Allocator_calloc(alloc, sizeof(*hdr), 1);
-    cap_user_data_t data = Allocator_calloc(alloc, sizeof(*data), 1);
+    cap_user_data_t data = Allocator_calloc(alloc, sizeof(*data), 2);
 
     hdr->version = _LINUX_CAPABILITY_VERSION_3;
     hdr->pid = 0;
@@ -73,7 +73,7 @@ void Setuid_preSetuid(struct Allocator* alloc, struct Except* eh)
 void Setuid_postSetuid(struct Allocator* alloc, struct Except* eh)
 {
     cap_user_header_t hdr = Allocator_calloc(alloc, sizeof(*hdr), 1);
-    cap_user_data_t data = Allocator_calloc(alloc, sizeof(*data), 1);
+    cap_user_data_t data = Allocator_calloc(alloc, sizeof(*data), 2);
 
     hdr->version = _LINUX_CAPABILITY_VERSION_3;
     hdr->pid = 0;


### PR DESCRIPTION
_LINUX_CAPABILITY_VERSION defaults to _LINUX_CAPABILITY_VERSION_1 which
only supports 32-bit capabilities. Use _LINUX_CAPABILITY_VERSION_3 for
64-bit capability support.

Gets rid of warning printed to the kernel ring buffer on newer kernels.

Signed-off-by: Johannes Löthberg <johannes@kyriasis.com>

---

If there's a hard-requirement on supporting 8 year old kernels I can add an `#ifndef`, though I'd rather not…