### PR TITLE
Allow custom pipe directory in configuation file

### DIFF
--- a/admin/angel/Core.c
+++ b/admin/angel/Core.c
@@ -245,7 +245,7 @@ int Core_main(int argc, char** argv)
 {
     struct Except* eh = NULL;
 
-    if (argc != 3) {
+    if (argc != 4) {
         Except_throw(eh, "This is internal to cjdns and shouldn't started manually.");
     }
 
@@ -264,7 +264,7 @@ int Core_main(int argc, char** argv)
     Allocator_setCanary(alloc, (unsigned long)Random_uint64(rand));
 
     struct Allocator* tempAlloc = Allocator_child(alloc);
-    struct Pipe* clientPipe = Pipe_named(argv[2], eventBase, eh, tempAlloc);
+    struct Pipe* clientPipe = Pipe_named(argv[2], argv[3], eventBase, eh, tempAlloc);
     clientPipe->logger = logger;
     Log_debug(logger, "Getting pre-configuration from client");
     struct Message* preConf =

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -400,6 +400,17 @@ static int genconf(struct Random* rand, bool eth)
           else {
     printf("    \"noBackground\":0,\n");
           }
+    printf("\n"
+           "    // Pipe file will store in this path, recommended value: /tmp (for unix),\n"
+           "    // \\\\.\\pipe (for windows) \n"
+           "    // /data/local/tmp (for rooted android) \n"
+           "    // /data/data/AppName (for non-root android)\n");
+          if (Defined(android)) {
+    printf("    \"pipe\":\"/data/local/tmp\",\n");
+          }
+          else if (!Defined(win32)){
+    printf("    \"pipe\":\"/tmp\",\n");
+          }
     printf("}\n");
 
     return 0;
@@ -634,12 +645,20 @@ int main(int argc, char** argv)
     struct Allocator* corePipeAlloc = Allocator_child(allocator);
     char corePipeName[64] = "client-core-";
     Random_base32(rand, (uint8_t*)corePipeName+CString_strlen(corePipeName), 31);
+    String* pipePath = Dict_getString(&config, String_CONST("pipe"));
+    if (!pipePath) {
+        pipePath = String_CONST(Pipe_PATH);
+    }
+    if (!Defined(win32) && access(pipePath->bytes, W_OK)) {
+        Except_throw(eh, "Can't have writable permission to pipe directory.");
+    }
     Assert_ifParanoid(EventBase_eventCount(eventBase) == 0);
-    struct Pipe* corePipe = Pipe_named(corePipeName, eventBase, eh, corePipeAlloc);
+    struct Pipe* corePipe = Pipe_named(pipePath->bytes, corePipeName, eventBase,
+                                       eh, corePipeAlloc);
     Assert_ifParanoid(EventBase_eventCount(eventBase) == 2);
     corePipe->logger = logger;
 
-    char* args[] = { "core", corePipeName, NULL };
+    char* args[] = { "core", pipePath->bytes, corePipeName, NULL };
 
     // --------------------- Spawn Angel --------------------- //
     String* privateKey = Dict_getString(&config, String_CONST("privateKey"));

--- a/interface/tuntap/AndroidWrapper.c
+++ b/interface/tuntap/AndroidWrapper.c
@@ -1,0 +1,103 @@
+/* vim: set expandtab ts=4 sw=4: */
+/*
+ * You may redistribute this program and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "interface/Iface.h"
+#include "interface/tuntap/AndroidWrapper.h"
+#include "util/platform/Sockaddr.h"
+#include "memory/Allocator.h"
+#include "util/Hex.h"
+#include "util/Assert.h"
+#include "util/Identity.h"
+#include "wire/Ethernet.h"
+#include "wire/Headers.h"
+#include "wire/Message.h"
+#include "wire/Error.h"
+
+/**
+ * Android VpnService is expect you to read/write packet from the tun device
+ * file description opened by system process rather than in the cjd process,
+ * this InterfaceWrapper handle this case.
+ */
+
+struct AndroidWrapper_pvt
+{
+    struct AndroidWrapper pub;
+    struct Log* logger;
+    Identity
+};
+
+static Iface_DEFUN incomingFromWire(struct Message* msg, struct Iface* externalIf)
+{
+    struct AndroidWrapper_pvt* ctx =
+        Identity_containerOf(externalIf, struct AndroidWrapper_pvt, pub.externalIf);
+
+    int version = Headers_getIpVersion(msg->bytes);
+    uint16_t ethertype = 0;
+    if (version == 4) {
+        ethertype = Ethernet_TYPE_IP4;
+    } else if (version == 6) {
+        ethertype = Ethernet_TYPE_IP6;
+    } else {
+        Log_debug(ctx->logger, "Message is not IP/IPv6, dropped.");
+        return NULL;
+    }
+    Message_shift(msg, 4, NULL);
+    ((uint16_t*) msg->bytes)[0] = 0;
+    ((uint16_t*) msg->bytes)[1] = ethertype;
+
+    if (msg->length < 128) {
+        char buf[256] = {0};
+        Hex_encode(buf, msg->length * 2, msg->bytes, msg->length);
+        Log_debug(ctx->logger, "recv %d msg(%d): %s", version, msg->length, buf);
+    }
+
+    if (!ctx->pub.internalIf.connectedIf) {
+        Log_debug(ctx->logger, "DROP message for android tun not inited");
+        return NULL;
+    }
+
+    return Iface_next(&ctx->pub.internalIf, msg);
+}
+
+static Iface_DEFUN incomingFromUs(struct Message* msg, struct Iface* internalIf)
+{
+    struct AndroidWrapper_pvt* ctx =
+        Identity_containerOf(internalIf, struct AndroidWrapper_pvt, pub.internalIf);
+
+    Message_shift(msg, -4, NULL);
+    if (msg->length < 128) {
+        char buf[256] = {0};
+        Hex_encode(buf, msg->length * 2, msg->bytes, msg->length);
+        Log_debug(ctx->logger, "send msg(%d): %s", msg->length, buf);
+    }
+
+    if (!ctx->pub.externalIf.connectedIf) {
+        Log_debug(ctx->logger, "DROP message for android tun not inited");
+        return NULL;
+    }
+
+    return Iface_next(&ctx->pub.externalIf, msg);
+}
+
+struct AndroidWrapper* AndroidWrapper_new(struct Allocator* alloc, struct Log* log)
+{
+    struct AndroidWrapper_pvt* context =
+        Allocator_calloc(alloc, sizeof(struct AndroidWrapper_pvt), 1);
+    Identity_set(context);
+    context->pub.externalIf.send = incomingFromWire;
+    context->pub.internalIf.send = incomingFromUs;
+    context->logger = log;
+
+    return &context->pub;
+}

--- a/interface/tuntap/AndroidWrapper.h
+++ b/interface/tuntap/AndroidWrapper.h
@@ -1,0 +1,32 @@
+/* vim: set expandtab ts=4 sw=4: */
+/*
+ * You may redistribute this program and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef AndroidWrapper_H
+#define AndroidWrapper_H
+
+#include "interface/Iface.h"
+#include "memory/Allocator.h"
+#include "util/log/Log.h"
+#include "util/Linker.h"
+Linker_require("interface/tuntap/AndroidWrapper.c");
+
+struct AndroidWrapper
+{
+    struct Iface internalIf;
+    struct Iface externalIf;
+};
+
+struct AndroidWrapper* AndroidWrapper_new(struct Allocator* alloc, struct Log* log);
+
+#endif

--- a/util/events/Pipe.h
+++ b/util/events/Pipe.h
@@ -51,17 +51,18 @@ struct Pipe
 #define Pipe_PADDING_AMOUNT 512
 #define Pipe_BUFFER_CAP 4000
 
-#ifndef Pipe_PREFIX
+#ifndef Pipe_PATH
     #ifdef win32
-        #define Pipe_PREFIX "\\\\.\\pipe\\cjdns_pipe_"
+        #define Pipe_PATH "\\\\.\\pipe"
     #elif defined(android)
-        #define Pipe_PREFIX "/data/local/tmp/cjdns_pipe_"
+        #define Pipe_PATH "/data/local/tmp"
     #else
-        #define Pipe_PREFIX "/tmp/cjdns_pipe_"
+        #define Pipe_PATH "/tmp"
     #endif
 #endif
 
-struct Pipe* Pipe_named(const char* name,
+struct Pipe* Pipe_named(const char* path,
+                        const char* name,
                         struct EventBase* eb,
                         struct Except* eh,
                         struct Allocator* userAlloc);

--- a/util/events/Pipe.h
+++ b/util/events/Pipe.h
@@ -18,6 +18,7 @@
 #include "memory/Allocator.h"
 #include "exception/Except.h"
 #include "interface/Iface.h"
+#include "interface/tuntap/AndroidWrapper.h"
 #include "util/events/EventBase.h"
 #include "util/Linker.h"
 Linker_require("util/events/libuv/Pipe.c");
@@ -73,4 +74,9 @@ struct Pipe* Pipe_forFiles(int inFd,
                            struct Except* eh,
                            struct Allocator* userAlloc);
 
+struct Pipe* Pipe_forAndroidHandle(struct AndroidWrapper* aw,
+                                   const char* pipe_path,
+                                   struct EventBase* eb,
+                                   struct Except* eh,
+                                   struct Allocator* userAlloc);
 #endif

--- a/util/events/libuv/Pipe.c
+++ b/util/events/libuv/Pipe.c
@@ -25,6 +25,9 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#define NOIPC   0
+#define IPC     1
+
 struct Pipe_WriteRequest_pvt;
 
 struct Pipe_pvt
@@ -58,6 +61,8 @@ struct Pipe_pvt
     struct Pipe_WriteRequest_pvt* bufferedRequest;
 
     struct Allocator* alloc;
+
+    struct AndroidWrapper* aw;
 
     Identity
 };
@@ -208,6 +213,54 @@ static void incoming(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
     }
 }
 
+#ifndef win32
+static void incoming2(uv_pipe_t* stream,
+                      ssize_t nread,
+                      const uv_buf_t* buf,
+                      uv_handle_type pending)
+{
+    struct Pipe_pvt* pipe = Identity_check((struct Pipe_pvt*) stream->data);
+
+    // Grab out the allocator which was placed there by allocate()
+    struct Allocator* alloc = buf->base ? ALLOC(buf->base) : NULL;
+    pipe->isInCallback = 1;
+
+    Assert_true(!alloc || alloc->fileName == pipe->alloc->fileName ||
+                pending == UV_UNKNOWN_HANDLE);
+
+    if (nread < 0) {
+        if (pipe->pub.onClose) {
+            pipe->pub.onClose(&pipe->pub, 0);
+        }
+        uv_close((uv_handle_t*) stream, onClose);
+
+    } else if (nread == 0) {
+        // This is common.
+        //Log_debug(pipe->pub.logger, "Pipe 0 length read [%s]", pipe->pub.fullName);
+
+    } else {
+        if (pipe->peer.accepted_fd != -1 && pipe->aw) {
+            struct Pipe* p = Pipe_forFiles(pipe->peer.accepted_fd, pipe->peer.accepted_fd,
+                                           pipe->pub.base, NULL, pipe->alloc);
+            p->logger = pipe->pub.logger;
+            if (pipe->aw->externalIf.connectedIf) {
+                Iface_unplumb(pipe->aw->externalIf.connectedIf, &pipe->aw->externalIf);
+            }
+            Iface_plumb(&pipe->aw->externalIf, &p->iface);
+        }
+    }
+
+    if (alloc) {
+        Allocator_free(alloc);
+    }
+
+    pipe->isInCallback = 0;
+    if (pipe->blockFreeInsideCallback) {
+        Allocator_onFreeComplete((struct Allocator_OnFreeJob*) pipe->blockFreeInsideCallback);
+    }
+}
+#endif
+
 static void allocate(uv_handle_t* handle, size_t size, uv_buf_t* buf)
 {
     struct Pipe_pvt* pipe = Identity_check((struct Pipe_pvt*) handle->data);
@@ -236,11 +289,19 @@ static void connected(uv_connect_t* req, int status)
                  pipe->pub.fullName, uv_strerror(status) );
         uv_close((uv_handle_t*) &pipe->peer, onClose);
 
-    } else if ((ret = uv_read_start((uv_stream_t*)&pipe->peer, allocate, incoming))) {
+    } else if ((!pipe->aw) && (ret = uv_read_start((uv_stream_t*)&pipe->peer,
+                                                    allocate, incoming))) {
         Log_info(pipe->pub.logger, "uv_read_start() failed for pipe [%s] [%s]",
                  pipe->pub.fullName, uv_strerror(ret));
         uv_close((uv_handle_t*) &pipe->peer, onClose);
 
+    #ifndef win32
+    } else if (pipe->aw && (ret = uv_read2_start((uv_stream_t*)&pipe->peer,
+                                                 allocate, incoming2))) {
+        Log_info(pipe->pub.logger, "uv_read2_start() failed for pipe [%s] [%s]",
+                 pipe->pub.fullName, uv_strerror(ret));
+        uv_close((uv_handle_t*) &pipe->peer, onClose);
+    #endif
     } else {
         pipe->isActive = 1;
 
@@ -328,6 +389,7 @@ static int closeHandlesOnFree(struct Allocator_OnFreeJob* job)
 static struct Pipe_pvt* newPipe(struct EventBase* eb,
                                 const char* path,
                                 const char* name,
+                                int ipc,
                                 struct Except* eh,
                                 struct Allocator* userAlloc)
 {
@@ -337,19 +399,23 @@ static struct Pipe_pvt* newPipe(struct EventBase* eb,
     char prefix[32] = {0};
     if (Defined(win32)) {
         Bits_memcpy(prefix, "\\cjdns_pipe_", CString_strlen("\\cjdns_pipe_"));
-    } else {
+    } else if (name){
         Bits_memcpy(prefix, "/cjdns_pipe_", CString_strlen("/cjdns_pipe_"));
     }
-    char* cname = Allocator_malloc(alloc, (path ? CString_strlen(path) : 0) +
-                                   CString_strlen(prefix) + CString_strlen(name) + 1);
+    int len = (path ? CString_strlen(path) : 0) + CString_strlen(prefix) +
+        (name ? CString_strlen(name) : 0) + 1;
+    char* cname = Allocator_malloc(alloc, len);
+    Bits_memset(cname, 0, len);
     int pos = 0;
     if (path) {
         Bits_memcpy(cname, path, CString_strlen(path));
         pos += CString_strlen(path);
     }
-    Bits_memcpy(cname + pos, prefix, CString_strlen(prefix));
-    pos += CString_strlen(prefix);
-    Bits_memcpy(cname + pos, name, CString_strlen(name) + 1);
+    if (name) {
+        Bits_memcpy(cname + pos, prefix, CString_strlen(prefix));
+        pos += CString_strlen(prefix);
+        Bits_memcpy(cname + pos, name, CString_strlen(name) + 1);
+    }
 
     struct Pipe_pvt* out = Allocator_clone(alloc, (&(struct Pipe_pvt) {
         .pub = {
@@ -365,12 +431,12 @@ static struct Pipe_pvt* newPipe(struct EventBase* eb,
 
     int ret;
 
-    ret = uv_pipe_init(ctx->loop, &out->peer, 0);
+    ret = uv_pipe_init(ctx->loop, &out->peer, ipc);
     if (ret) {
         Except_throw(eh, "uv_pipe_init() failed [%s]", uv_strerror(ret));
     }
 
-    ret = uv_pipe_init(ctx->loop, &out->server, 0);
+    ret = uv_pipe_init(ctx->loop, &out->server, ipc);
     if (ret) {
         Except_throw(eh, "uv_pipe_init() failed [%s]", uv_strerror(ret));
     }
@@ -401,7 +467,7 @@ struct Pipe* Pipe_forFiles(int inFd,
     char buff[32] = {0};
     snprintf(buff, 31, "forFiles(%d,%d)", inFd, outFd);
 
-    struct Pipe_pvt* out = newPipe(eb, NULL, buff, eh, userAlloc);
+    struct Pipe_pvt* out = newPipe(eb, NULL, buff, NOIPC, eh, userAlloc);
 
     int ret = uv_pipe_open(&out->peer, inFd);
     if (ret) {
@@ -430,7 +496,7 @@ struct Pipe* Pipe_named(const char* path,
                         struct Except* eh,
                         struct Allocator* userAlloc)
 {
-    struct Pipe_pvt* out = newPipe(eb, path, name, eh, userAlloc);
+    struct Pipe_pvt* out = newPipe(eb, path, name, NOIPC, eh, userAlloc);
     int ret;
 
     // Attempt to create pipe.
@@ -449,6 +515,34 @@ struct Pipe* Pipe_named(const char* path,
         uv_connect_t* req = Allocator_malloc(out->alloc, sizeof(uv_connect_t));
         req->data = out;
         uv_pipe_connect(req, &out->peer, out->pub.fullName, connected);
+        return &out->pub;
+    }
+
+    Except_throw(eh, "uv_pipe_bind() failed [%s] for pipe [%s]",
+                 uv_strerror(ret), out->pub.fullName);
+
+    return &out->pub;
+}
+
+struct Pipe* Pipe_forAndroidHandle(struct AndroidWrapper* aw,
+                                   const char* pipe_path,
+                                   struct EventBase* eb,
+                                   struct Except* eh,
+                                   struct Allocator* userAlloc)
+{
+    struct Pipe_pvt* out = newPipe(eb, pipe_path, NULL, IPC, eh, userAlloc);
+
+    uv_fs_t req;
+    uv_fs_unlink(out->server.loop, &req, out->pub.fullName, NULL);
+
+    int ret = uv_pipe_bind(&out->server, out->pub.fullName);
+    if (!ret) {
+        ret = uv_listen((uv_stream_t*) &out->server, 1, listenCallback);
+        if (ret) {
+            Except_throw(eh, "uv_listen() failed [%s] for pipe [%s]",
+                         uv_strerror(ret), out->pub.fullName);
+        }
+        out->aw = aw;
         return &out->pub;
     }
 

--- a/util/test/Process_test.c
+++ b/util/test/Process_test.c
@@ -102,7 +102,7 @@ static Iface_DEFUN receiveMessageChild(struct Message* msg, struct Iface* iface)
 
 static void child(char* name, struct Context* ctx)
 {
-    struct Pipe* pipe = Pipe_named(name, ctx->base, NULL, ctx->alloc);
+    struct Pipe* pipe = Pipe_named(Pipe_PATH, name, ctx->base, NULL, ctx->alloc);
     pipe->logger = ctx->log;
     pipe->onConnection = onConnectionChild;
     pipe->userData = ctx;
@@ -133,7 +133,7 @@ int main(int argc, char** argv)
     char name[32] = {0};
     Random_base32(rand, (uint8_t*)name, 31);
 
-    struct Pipe* pipe = Pipe_named(name, eb, NULL, alloc);
+    struct Pipe* pipe = Pipe_named(Pipe_PATH, name, eb, NULL, alloc);
     pipe->logger = log;
     pipe->userData = ctx;
     pipe->onConnection = onConnectionParent;

--- a/util/test/Seccomp_test.c
+++ b/util/test/Seccomp_test.c
@@ -65,7 +65,7 @@ static void timeout(void* vNULL)
 static int child(char* pipeName, struct Allocator* alloc, struct Log* logger)
 {
     struct EventBase* eb = EventBase_new(alloc);
-    struct Pipe* pipe = Pipe_named(pipeName, eb, NULL, alloc);
+    struct Pipe* pipe = Pipe_named(Pipe_PATH, pipeName, eb, NULL, alloc);
     pipe->onConnection = onConnectionChild;
     pipe->logger = logger;
     pipe->userData = alloc;
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
     ctx->iface.send = receiveMessageParent;
     ctx->eventBase = eb;
 
-    struct Pipe* pipe = Pipe_named(name, eb, NULL, alloc);
+    struct Pipe* pipe = Pipe_named(Pipe_PATH, name, eb, NULL, alloc);
     pipe->logger = logger;
     Iface_plumb(&ctx->iface, &pipe->iface);
 


### PR DESCRIPTION
User should be allowed to define the pipe file location as different OS required. For example, non-rooted android only allow app have the write permission to the /data/data/app.package.name/ but not the default /data/local/tmp. 