### PR TITLE
contrib: update openrc script with new interpreter naming

### DIFF
--- a/contrib/openrc/cjdns
+++ b/contrib/openrc/cjdns
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 description="Encrypted networking for regular people."
 
 CONFFILE=/etc/cjdroute.conf


### PR DESCRIPTION
Reflect the deprecation of /sbin/runscript as shown here: https://archives.gentoo.org/gentoo-user/message/70b36402114f15e88fe0a867ac4d499d