### PR TITLE
node_build: allow specifying a different temp directory

### DIFF
--- a/node_build/make.js
+++ b/node_build/make.js
@@ -45,7 +45,7 @@ Builder.configure({
     systemName:     SYSTEM,
     crossCompiling: process.env['CROSS'] !== undefined,
     gcc:            GCC,
-    tempDir:        '/tmp',
+    tempDir:        process.env['CJDNS_BUILD_TMPDIR'] || '/tmp',
     optimizeLevel:  '-O3',
     logLevel:       process.env['Log_LEVEL'] || 'DEBUG'
 }, function (builder, waitFor) {


### PR DESCRIPTION
In some situations it might be desirable to use a different temporary directory
when building, for example to not pollute the host system when frequently doing
automated cross builds.

Make `make.js` accept a `$CJDNS_BUILD_TMPDIR` variable and fall back to `/tmp`
if it is unset.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>