### PR TITLE
tunnel,util: cast before left-shift to silence warn

### DIFF
--- a/tunnel/RouteGen.c
+++ b/tunnel/RouteGen.c
@@ -298,7 +298,7 @@ static struct ArrayList_OfPrefix4* invertPrefix4(struct Prefix4* toInvert, struc
     struct ArrayList_OfPrefix4* result = ArrayList_OfPrefix4_new(alloc);
     for (int i = 32 - toInvert->prefix; i < 32; i++) {
         struct Prefix4* pfx = Allocator_calloc(alloc, sizeof(struct Prefix4), 1);
-        pfx->bits = ( toInvert->bits & (~0 << i) ) ^ (1 << i);
+        pfx->bits = ( toInvert->bits & ((uint32_t)~0 << i) ) ^ (1 << i);
         pfx->prefix = 32 - i;
         ArrayList_OfPrefix4_add(result, pfx);
     }

--- a/util/platform/netdev/NetPlatform_linux.c
+++ b/util/platform/netdev/NetPlatform_linux.c
@@ -163,7 +163,7 @@ void NetPlatform_addAddress(const char* interfaceName,
             Except_throw(eh, "ioctl(SIOCSIFADDR) failed: [%s]", strerror(err));
         }
 
-        uint32_t x = ~0 << (32 - prefixLen);
+        uint32_t x = (uint32_t)~0 << (32 - prefixLen);
         x = Endian_hostToBigEndian32(x);
         memcpy(&sin.sin_addr, &x, 4);
         memcpy(&ifRequest.ifr_addr, &sin, sizeof(struct sockaddr_in));


### PR DESCRIPTION
GCC v6.1.1 complained (at least on armv7h) about signed left shift.