### PR TITLE
interface: linux: re-order if.h includes to fix undeclared IFNAMSIZ

### DIFF
--- a/interface/tuntap/TUNInterface_linux.c
+++ b/interface/tuntap/TUNInterface_linux.c
@@ -27,12 +27,12 @@
 #include <sys/types.h>
 #include <stdlib.h>
 #include <stddef.h>
-#include <net/if.h>
 #include <arpa/inet.h>
 #include <string.h>
 #include <linux/if.h>
 #include <linux/if_tun.h>
 #include <linux/if_ether.h>
+#include <net/if.h>
 
 #if defined(android)
   #define DEVICE_PATH "/dev/tun"

--- a/util/platform/netdev/NetPlatform_linux.c
+++ b/util/platform/netdev/NetPlatform_linux.c
@@ -31,13 +31,13 @@
 #include <sys/types.h>
 #include <stdlib.h>
 #include <stddef.h>
-#include <net/if.h>
 #include <arpa/inet.h>
 #include <linux/if.h>
 #include <linux/route.h>
 #include <linux/ipv6_route.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
+#include <net/if.h>
 
 // Way to identify our routes as opposed to statically created or otherwise...
 #define RTPROT_CJDNS 52


### PR DESCRIPTION
This is a workaround for compile error:
undeclared identifier IFNAMSIZ

Some resources about it, apparently related to glibc:
https://www.spinics.net/lists/kernel/msg2252828.html
