### PR TITLE
use python2 in cexec

### DIFF
--- a/contrib/python/cexec
+++ b/contrib/python/cexec
@@ -1,3 +1,3 @@
 #!/bin/sh
 BASEDIR=$(dirname $0)
-python "$BASEDIR/cjdnsadmin/cli.py" $@
+python2 "$BASEDIR/cjdnsadmin/cli.py" $@


### PR DESCRIPTION
`python` maps to Python v3 on Arch, but this script seems to not be compatible with Python v2 only. 