### PR TITLE
cnacl: ARM build plans: remove duplicate typedefs

### DIFF
--- a/node_build/dependencies/cnacl/node_build/plans/apple_armeabi_plan.json
+++ b/node_build/dependencies/cnacl/node_build/plans/apple_armeabi_plan.json
@@ -118,9 +118,7 @@
     "typedef long long crypto_int64;",
     "typedef unsigned char crypto_uint8;",
     "typedef unsigned long long crypto_uint64;",
-    "typedef signed long long crypto_int64;",
     "typedef unsigned int crypto_uint32;",
-    "typedef signed int crypto_int32;",
     "typedef unsigned short crypto_uint16;"
   ]
 }

--- a/node_build/dependencies/cnacl/node_build/plans/arm64_plan.json
+++ b/node_build/dependencies/cnacl/node_build/plans/arm64_plan.json
@@ -118,9 +118,7 @@
     "typedef long long crypto_int64;",
     "typedef unsigned char crypto_uint8;",
     "typedef unsigned long long crypto_uint64;",
-    "typedef signed long long crypto_int64;",
     "typedef unsigned int crypto_uint32;",
-    "typedef signed int crypto_int32;",
     "typedef unsigned short crypto_uint16;"
   ]
 }

--- a/node_build/dependencies/cnacl/node_build/plans/armeabi_plan.json
+++ b/node_build/dependencies/cnacl/node_build/plans/armeabi_plan.json
@@ -118,9 +118,7 @@
     "typedef long long crypto_int64;",
     "typedef unsigned char crypto_uint8;",
     "typedef unsigned long long crypto_uint64;",
-    "typedef signed long long crypto_int64;",
     "typedef unsigned int crypto_uint32;",
-    "typedef signed int crypto_int32;",
     "typedef unsigned short crypto_uint16;"
   ]
 }


### PR DESCRIPTION
Duplicate typedefs caused build to fail due to fatal warning on ARMv7h,
gcc 6.1.1 (Arch Linux).

```
/home/redfish/dev/cjdns-git/src/cjdns/node_build/builder.js:485
            if (err) { throw err; }
                       ^

Error: gcc -c -x cpp-output -o build_linux/crypto_Sign_c.o -std=c99 -Wall -Wextra -Werror -Wno-pointer-sign -pedantic -D linux=1 -D CJD_PACKAGE_VERSION="cjdns-v17.4-23-g113d160" -Wno-unused-parameter -D Log_DEBUG -g -D NumberCompress_TYPE=v3x5x8 -D Identity_CHECK=1 -D Allocator_USE_CANARIES=1 -D PARANOIA=1 -DHAS_ETH_INTERFACE=1 -fPIE -fno-stack-protector -fstack-protector-all -Wstack-protector -O3 build_linux/crypto_Sign_c.o.i

In file included from build_linux/dependencies/cnacl/jsbuild/include_internal/crypto_int32.h:1:0,
                 from ./node_build/dependencies/cnacl/crypto_sign/ed25519/ref10/fe.h:4,
                 from ./node_build/dependencies/cnacl/crypto_sign/ed25519/ref10/ge.h:18,
                 from crypto/Sign.c:18:
build_linux/dependencies/cnacl/jsbuild/include_internal/crypto_types.h:9:26: error: redefinition of typedef ‘crypto_int64’ [-Werror=pedantic]
 typedef signed long long crypto_int64;
                          ^~~~~~~~~~~~
build_linux/dependencies/cnacl/jsbuild/include_internal/crypto_types.h:6:19: note: previous declaration of ‘crypto_int64’ was here
 typedef long long crypto_int64;
                   ^~~~~~~~~~~~
build_linux/dependencies/cnacl/jsbuild/include_internal/crypto_types.h:11:20: error: redefinition of typedef ‘crypto_int32’ [-Werror=pedantic]
 typedef signed int crypto_int32;
                    ^~~~~~~~~~~~
build_linux/dependencies/cnacl/jsbuild/include_internal/crypto_types.h:4:20: note: previous declaration of ‘crypto_int32’ was here
 typedef signed int crypto_int32;
                    ^~~~~~~~~~~~
cc1: all warnings being treated as errors

    at error (/home/redfish/dev/cjdns-git/src/cjdns/node_build/builder.js:53:15)
    at /home/redfish/dev/cjdns-git/src/cjdns/node_build/builder.js:122:22
    at /home/redfish/dev/cjdns-git/src/cjdns/node_build/builder.js:92:13
    at ChildProcess.<anonymous> (/home/redfish/dev/cjdns-git/src/cjdns/tools/lib/Semaphore.js:7:30)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:852:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:215:5)
```