### PR TITLE
Remove support for connecting to peers by hostnames

### DIFF
--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -220,21 +220,9 @@ static void udpInterface(Dict* config, struct Context* ctx)
                     // it's a sockaddr, fall through
                 } else if (lastColon) {
                     // try it as a hostname.
-                    int port = atoi(lastColon+1);
-                    if (!port) {
-                        Log_critical(ctx->logger, "Couldn't get port number from [%s]", key->bytes);
-                        exit(-1);
-                    }
-                    *lastColon = '\0';
-                    struct Sockaddr* adr = Sockaddr_fromName(key->bytes, perCallAlloc);
-                    if (adr != NULL) {
-                        Sockaddr_setPort(adr, port);
-                        key = String_new(Sockaddr_print(adr, perCallAlloc), perCallAlloc);
-                    } else {
-                        Log_warn(ctx->logger, "Failed to lookup hostname [%s]", key->bytes);
-                        entry = entry->next;
-                        continue;
-                    }
+                    Log_critical(ctx->logger, "Couldn't add connection [%s], "
+                                                "hostnames aren't supported.", key->bytes);
+                    exit(-1);
                 }
                 Dict_putInt(value, String_CONST("interfaceNumber"), ifNum, perCallAlloc);
                 Dict_putString(value, String_CONST("address"), key, perCallAlloc);

--- a/util/platform/Sockaddr.c
+++ b/util/platform/Sockaddr.c
@@ -316,18 +316,6 @@ void Sockaddr_normalizeNative(void* nativeSockaddr)
 #endif
 }
 
-struct Sockaddr* Sockaddr_fromName(char* name, struct Allocator* alloc)
-{
-    struct addrinfo* servinfo;
-    if (getaddrinfo(name, 0, NULL, &servinfo) == 0) {
-        struct Sockaddr* adr;
-        adr = Sockaddr_fromNative(servinfo->ai_addr, servinfo->ai_addrlen, alloc);
-        freeaddrinfo(servinfo);
-        return adr;
-    }
-    return NULL;
-}
-
 uint32_t Sockaddr_hash(const struct Sockaddr* addr)
 {
     return Hash_compute((uint8_t*)addr, addr->addrLen);

--- a/util/platform/Sockaddr.h
+++ b/util/platform/Sockaddr.h
@@ -127,8 +127,6 @@ static inline const void* Sockaddr_asNativeConst(const struct Sockaddr* sa)
     return (const void*)(&sa[1]);
 }
 
-struct Sockaddr* Sockaddr_fromName(char* name, struct Allocator* alloc);
-
 /**
  * Contrast with Sockaddr_fromNative(), Sockaddr_fromBytes() takes
  * input as the bytes of the address eg: Sockaddr_fromBytes({127,0,0,1}, Sockaddr_AF_INET, alloc)

--- a/util/platform/test/Sockaddr_test.c
+++ b/util/platform/test/Sockaddr_test.c
@@ -69,19 +69,9 @@ static void parse()
     expectFailure("1.0.0.");
 }
 
-static void fromName()
-{
-    struct Allocator* alloc = MallocAllocator_new(20000);
-    Sockaddr_fromName("localhost", alloc);
-    // This will fail in some cases (eg dns hijacking)
-    //Assert_true(!Sockaddr_fromName("hasjklgyolgbvlbiogi", alloc));
-    Allocator_free(alloc);
-}
-
 
 int main()
 {
     parse();
-    fromName();
     return 0;
 }


### PR DESCRIPTION
It causes more issues than it's worth already.

1) Hostnames are only resolved on startup, making them much less useful.
2) It doesn't actually currently check the address family of the resolved address, and adding support for it is a bit hairy.