### PR TITLE
Fix README Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ it will be downloaded and installed in the source tree.
 
 #### Fedora 22+ based distro:
 
-    sudo dnf install install nodejs git
+    sudo dnf install nodejs git
     sudo dnf install @development-tools
 
 #### RHEL based distro (adds the EPEL repo):
 
     sudo yum localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    sudo yum install install nodejs git
+    sudo yum install nodejs git
     sudo yum install @development-tools
 
 #### OS X:


### PR DESCRIPTION
Double "install" in RHEL and Fedora installation instructions