### PR TITLE
fix ipTunnel IPv6 comparison macro

### DIFF
--- a/tunnel/IpTunnel.c
+++ b/tunnel/IpTunnel.c
@@ -605,8 +605,8 @@ static Iface_DEFUN incomingControlMessage(struct Message* message,
 #define GET64(buffer) \
     (__extension__ ({                                               \
         Assert_true(!((long)(buffer) % 4));                         \
-        uint64_t x = (uint64_t) (((uint32_t*)(buffer))[0]) << 32;   \
-        x |= ((uint32_t*)(buffer))[1];                              \
+        uint64_t x = (uint64_t) (((uint32_t*)(buffer))[0]);         \
+        x |= (( (uint64_t) ((uint32_t*)(buffer))[1]) << 32);        \
         Endian_bigEndianToHost64(x);                                \
     }))
 


### PR DESCRIPTION
Fix IPv6 address comparison macro GET64 in tunnel.c

Example:

Previously GET64 for address 2a00:1450:4010:c0b::5e returned 288525093217244240 (0x4010c0b2a001450), not 0x2a0014504010c0b which was the expected result.
