### PR TITLE
Added hinting of address family to `Sockaddr_fromName`

### DIFF
--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -198,6 +198,7 @@ static void udpInterface(Dict* config, struct Context* ctx)
         Dict* resp = NULL;
         rpcCall0(String_CONST("UDPInterface_new"), d, ctx, ctx->alloc, &resp, true);
         int ifNum = *(Dict_getInt(resp, String_CONST("interfaceNumber")));
+        String* bindAddr = Dict_getString(resp, String_CONST("bindAddress"));
 
         // Make the connections.
         Dict* connectTo = Dict_getDict(udp, String_CONST("connectTo"));
@@ -226,7 +227,7 @@ static void udpInterface(Dict* config, struct Context* ctx)
                         exit(-1);
                     }
                     *lastColon = '\0';
-                    struct Sockaddr* adr = Sockaddr_fromName(key->bytes, perCallAlloc);
+                    struct Sockaddr* adr = Sockaddr_fromName(key->bytes, *bindAddr->bytes == '[' ? AF_INET6 : AF_INET, perCallAlloc);
                     if (adr != NULL) {
                         Sockaddr_setPort(adr, port);
                         key = String_new(Sockaddr_print(adr, perCallAlloc), perCallAlloc);

--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -227,7 +227,9 @@ static void udpInterface(Dict* config, struct Context* ctx)
                         exit(-1);
                     }
                     *lastColon = '\0';
-                    struct Sockaddr* adr = Sockaddr_fromName(key->bytes, *bindAddr->bytes == '[' ? AF_INET6 : AF_INET, perCallAlloc);
+                    struct Sockaddr* adr = Sockaddr_fromName(key->bytes, *bindAddr->bytes == '[' ?
+                                                             Sockaddr_AF_INET6 : Sockaddr_AF_INET,
+                                                             perCallAlloc);
                     if (adr != NULL) {
                         Sockaddr_setPort(adr, port);
                         key = String_new(Sockaddr_print(adr, perCallAlloc), perCallAlloc);

--- a/util/platform/Sockaddr.c
+++ b/util/platform/Sockaddr.c
@@ -316,10 +316,12 @@ void Sockaddr_normalizeNative(void* nativeSockaddr)
 #endif
 }
 
-struct Sockaddr* Sockaddr_fromName(char* name, struct Allocator* alloc)
+struct Sockaddr* Sockaddr_fromName(char* name, int addrFamily, struct Allocator* alloc)
 {
     struct addrinfo* servinfo;
-    if (getaddrinfo(name, 0, NULL, &servinfo) == 0) {
+    struct addrinfo hints = {};
+    hints.ai_family = addrFamily;
+    if (getaddrinfo(name, 0, &hints, &servinfo) == 0) {
         struct Sockaddr* adr;
         adr = Sockaddr_fromNative(servinfo->ai_addr, servinfo->ai_addrlen, alloc);
         freeaddrinfo(servinfo);

--- a/util/platform/Sockaddr.c
+++ b/util/platform/Sockaddr.c
@@ -319,7 +319,7 @@ void Sockaddr_normalizeNative(void* nativeSockaddr)
 struct Sockaddr* Sockaddr_fromName(char* name, int addrFamily, struct Allocator* alloc)
 {
     struct addrinfo* servinfo;
-    struct addrinfo hints = {};
+    struct addrinfo hints = { 0 };
     hints.ai_family = addrFamily;
     if (getaddrinfo(name, 0, &hints, &servinfo) == 0) {
         struct Sockaddr* adr;

--- a/util/platform/Sockaddr.h
+++ b/util/platform/Sockaddr.h
@@ -127,7 +127,7 @@ static inline const void* Sockaddr_asNativeConst(const struct Sockaddr* sa)
     return (const void*)(&sa[1]);
 }
 
-struct Sockaddr* Sockaddr_fromName(char* name, struct Allocator* alloc);
+struct Sockaddr* Sockaddr_fromName(char* name, int addrFamily, struct Allocator* alloc);
 
 /**
  * Contrast with Sockaddr_fromNative(), Sockaddr_fromBytes() takes

--- a/util/platform/test/Sockaddr_test.c
+++ b/util/platform/test/Sockaddr_test.c
@@ -72,9 +72,9 @@ static void parse()
 static void fromName()
 {
     struct Allocator* alloc = MallocAllocator_new(20000);
-    Sockaddr_fromName("localhost", alloc);
+    Sockaddr_fromName("localhost", 0, alloc);
     // This will fail in some cases (eg dns hijacking)
-    //Assert_true(!Sockaddr_fromName("hasjklgyolgbvlbiogi", alloc));
+    //Assert_true(!Sockaddr_fromName("hasjklgyolgbvlbiogi", 0, alloc));
     Allocator_free(alloc);
 }
 


### PR DESCRIPTION
This resolves "different address type than this socket is bound to"
errors when a DNS name resolves to both an IPv4 and an IPv6 address.

Signed-off-by: Kieran Colford <kieran@kcolford.com>