### PR TITLE
Undocument the optionality of the login.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,15 +267,15 @@ In your conf file, you will see:
 "authorizedPasswords":
 [
     // A unique string which is known to the client and server.
-    {"password": "thisisauniquestring_001"}
+    {"password": "password001", "login": "default-login"}
 
     // More passwords should look like this.
-    // {"password": "thisisauniquestring_002"}
-    // {"password": "thisisauniquestring_003"}
-    // {"password": "thisisauniquestring_004"}
+    // {"password": "password002", "login": "my-second-peer"}
+    // {"password": "password003", "login": "my-third-peer}
+    // {"password": "password004", "login": "my-fourth-peer"}
     ...
 
-    // "your.external.ip.goes.here:45678":{"password": "thisisauniquestring_001","publicKey":thisisauniqueKEY_001.k"}
+    // "your.external.ip.goes.here:45678":{"login": "default-login", "password": "password001","publicKey":thisisauniqueKEY_001.k"}
 
 ],
 ```

--- a/README_DE.md
+++ b/README_DE.md
@@ -220,15 +220,15 @@ In deinem config File wirst du eine Passage wie folgt finden:
 "authorizedPasswords":
 [
     // A unique string which is known to the client and server.
-    {"password": "thisisauniquestring_001"}
+    {"password": "password001", "login": "default-login"}
 
     // More passwords should look like this.
-    // {"password": "thisisauniquestring_002"}
-    // {"password": "thisisauniquestring_003"}
-    // {"password": "thisisauniquestring_004"}
+    // {"password": "password002", "login": "my-second-peer"}
+    // {"password": "password003", "login": "my-third-peer}
+    // {"password": "password004", "login": "my-fourth-peer"}
     ...
 
-    // "your.external.ip.goes.here:45678":{"password": "thisisauniquestring_001","publicKey":thisisauniqueKEY_001.k"}
+    // "your.external.ip.goes.here:45678":{"login": "default-login", "password": "password001","publicKey":thisisauniqueKEY_001.k"}
 
 ],
 ```

--- a/README_GR.md
+++ b/README_GR.md
@@ -250,15 +250,15 @@ TUN/TAP συσκευή - αυτό είναι στάνταρ πρωτόκολλο
 "authorizedPasswords":
 [
     // A unique string which is known to the client and server.
-    {"password": "thisisauniquestring_001"}
+    {"password": "password001", "login": "default-login"}
 
     // More passwords should look like this.
-    // {"password": "thisisauniquestring_002"}
-    // {"password": "thisisauniquestring_003"}
-    // {"password": "thisisauniquestring_004"}
+    // {"password": "password002", "login": "my-second-peer"}
+    // {"password": "password003", "login": "my-third-peer}
+    // {"password": "password004", "login": "my-fourth-peer"}
     ...
 
-    // "your.external.ip.goes.here:45678":{"password": "thisisauniquestring_001","publicKey":thisisauniqueKEY_001.k"}
+    // "your.external.ip.goes.here:45678":{"login": "default-login", "password": "password001","publicKey":thisisauniqueKEY_001.k"}
 
 ],
 ```

--- a/README_HR.md
+++ b/README_HR.md
@@ -292,39 +292,38 @@ following JSON syntax.
 U Vašoj conf datoteci vidjeti ćete:
 ``` javascript
 "authorizedPasswords":
-    [
-        // A unique string which is known to the client and server.
-        {"password": "thisisauniquestring_001"}
+[
+    // A unique string which is known to the client and server.
+    {"password": "password001", "login": "default-login"}
 
-        // More passwords should look like this.
-        // {"password": "thisisauniquestring_002"}
-        // {"password": "thisisauniquestring_003"}
-        // {"password": "thisisauniquestring_004"}
-        ...
+    // More passwords should look like this.
+    // {"password": "password002", "login": "my-second-peer"}
+    // {"password": "password003", "login": "my-third-peer}
+    // {"password": "password004", "login": "my-fourth-peer"}
+    ...
 
-        // "your.external.ip.goes.here:45678":{"password": "thisisauniquestring_001","publicKey":thisisauniqueKEY_001.k"}
+    // "your.external.ip.goes.here:45678":{"login": "default-login", "password": "password001","publicKey":thisisauniqueKEY_001.k"}
 
-    ],
+],
 ```
 
 A conf file with multiple friend-nodes, setup INbound, should look like:
 ``` javascript
 "authorizedPasswords":
-    [
-        // A unique string which is known to the client and server.
-        {"password": "thisisauniquestring_001"}
+[
+    // A unique string which is known to the client and server.
+    {"password": "thisisauniquestring_001", "user": "k.alexander"}
 
-        // More passwords should look like this.
-        //friend_3 (IPv4: 0.1.2.3; IPv6 fcaa:5bac:66e4:713:cb00:e446:c317:fc39)
-        {"password": "thisisauniquestring_002"}
-        //friend_4 (IPv4: 5.1.2.3; IPv6 fcbb:5bac:66e4:713:cb00:e446:c317:fc39)
-        {"password": "thisisauniquestring_003"}
-        // {"password": "thisisauniquestring_004"}
-        ...
+    // More passwords should look like this.
+    //William Jevons (IPv4: 0.1.2.3; IPv6 fcaa:5bac:66e4:713:cb00:e446:c317:fc39)
+    {"password": "thisisauniquestring_002", "user": "William Jevons"}
+    //Marilyn Patel (IPv4: 5.1.2.3; IPv6 fcbb:5bac:66e4:713:cb00:e446:c317:fc39)
+    {"password": "thisisauniquestring_003", "user": "Marilyn Patel"}
+    // {"password": "thisisauniquestring_004"}
+    ...
 
-        // "your.external.ip.goes.here:45678":{"password": "thisisauniquestring_001","publicKey":thisisauniqueKEY_001.k"}
-
-    ],
+    // "your.external.ip.goes.here:45678":{"password": "thisisauniquestring_001","publicKey":thisisauniqueKEY_001.k"}
+],
 ```
 
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -162,6 +162,7 @@ The cjdns developers.
             {
                 "0.1.2.3:45678":
                 {
+                    "login": "user-login",
                     "password": "thisIsNotARealConnection",
                     "publicKey": "thisIsJustForAnExampleDoNotUseThisInYourConfFile.k"
                 }
@@ -180,6 +181,7 @@ The cjdns developers.
 
             "your.external.ip.goes.here:12345":
             {
+                "login": "user-login",
                 "password": "thisIsNotARealConnectionEither",
                 "publicKey": "thisIsAlsoJustForAnExampleDoNotUseThisInYourConfFile.k"
             }

--- a/README_SV.md
+++ b/README_SV.md
@@ -239,15 +239,15 @@ Leta upp `authorizedPasswords`-attributet i din konfigurationsfil:
 "authorizedPasswords":
 [
     // A unique string which is known to the client and server.
-    {"password": "thisisauniquestring_001"}
+    {"password": "password001", "login": "default-login"}
 
     // More passwords should look like this.
-    // {"password": "thisisauniquestring_002"}
-    // {"password": "thisisauniquestring_003"}
-    // {"password": "thisisauniquestring_004"}
+    // {"password": "password002", "login": "my-second-peer"}
+    // {"password": "password003", "login": "my-third-peer}
+    // {"password": "password004", "login": "my-fourth-peer"}
     ...
 
-    // "your.external.ip.goes.here:45678":{"password": "thisisauniquestring_001","publicKey":thisisauniqueKEY_001.k"}
+    // "your.external.ip.goes.here:45678":{"login": "default-login", "password": "password001","publicKey":thisisauniqueKEY_001.k"}
 
 ],
 ```

--- a/admin/AdminLog.c
+++ b/admin/AdminLog.c
@@ -229,7 +229,7 @@ static void subscribe(Dict* args, void* vcontext, String* txid, struct Allocator
 {
     struct AdminLog* log = Identity_check((struct AdminLog*) vcontext);
     String* levelName = Dict_getString(args, String_CONST("level"));
-    enum Log_Level level = (levelName) ? Log_levelForName(levelName->bytes) : Log_Level_DEBUG;
+    enum Log_Level level = (levelName) ? Log_levelForName(levelName->bytes) : Log_Level_KEYS;
     int64_t* lineNumPtr = Dict_getInt(args, String_CONST("line"));
     String* fileStr = Dict_getString(args, String_CONST("file"));
     if (fileStr && !fileStr->len) { fileStr = NULL; }

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -120,8 +120,7 @@ static int genconf(struct Random* rand, bool eth)
            "    \"authorizedPasswords\":\n"
            "    [\n"
            "        // A unique string which is known to the client and server.\n"
-           "        // Specify an optional user to identify the peer locally.\n"
-           "        // It is not used for authentication.\n"
+           "        // Specify a user to identify the peer locally.\n"
            "        {\"password\": \"%s\", \"user\": \"default-login\"}\n", password);
     printf("\n"
            "        // More passwords should look like this.\n"

--- a/crypto/CryptoAuth.c
+++ b/crypto/CryptoAuth.c
@@ -37,6 +37,7 @@
 #include "crypto_scalarmult_curve25519.h"
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stdbool.h>
 
 static inline void printHexKey(uint8_t output[65], uint8_t key[32])

--- a/doc/cjdns/peering-over-UDP-IP.md
+++ b/doc/cjdns/peering-over-UDP-IP.md
@@ -110,6 +110,7 @@ Prerequisites:
 
 ```javascript
         {
+                "user": "login for your peer",
                 "password": "vt1ly5f4ydmm9gjk196t160z23t6uju",
                 "name": "[put your peers name here]",
                 "contact": "[put your peers contact info here]"
@@ -117,6 +118,7 @@ Prerequisites:
 ```
 Things that are parsed:
 
+- login
 - password
 
 Everything else is for humans.
@@ -127,6 +129,7 @@ Everything else is for humans.
 
 ```javascript
                         "[your IP address]:[your open port]": {
+                                "login": "[the login your peer has for you]",
                                 "password": "[your long passphrase]",
                                 "location": "New York City, NY, US",
                                 "[insert cool noun here]": "[something witty]",
@@ -137,6 +140,7 @@ Everything else is for humans.
 ```
 Things that are parsed:
 
+- login
 - IP address and port number combo
 - password
 - pubkey
@@ -156,15 +160,16 @@ Like this.
         //default password
         {"password": "pnc8q05llp9sx7d1b4bc3d6ru0krgbl"},
         {
+                "user": "login for your peer",
                 "password": "vt1ly5f4ydmm9gjk196t160z23t6uju",
                 "name": "[put your peers name here]",
                 "contact": "[put your peers contact info here]"
         },
 
         // More passwords should look like this.
-        // {"password": "tjrwwlsh4ugddk032yu8vrnv11v8z5f"},
-        // {"password": "pm0643f911j71w0pctj5s7bkk0s8htv"},
-        // {"password": "2vls52j3q4151dk8h2kz939kt0ldu75"},
+        // {"password": "tjrwwlsh4ugddk032yu8vrnv11v8z5f", "user": "my-second-peer"},
+        // {"password": "pm0643f911j71w0pctj5s7bkk0s8htv", "user": "my-third-peer"},
+        // {"password": "2vls52j3q4151dk8h2kz939kt0ldu75", "user": "my-fourth-peer"},
 
         // Below is an example of your connection credentials
         // that you can give to other people so they can connect
@@ -172,7 +177,7 @@ Like this.
         // Adding a unique password for each user is advisable
         // so that leaks can be isolated.
         //
-        // "your.external.ip.goes.here:43653":{"password":"vt1ly5f4ydmm9gjk196t160z23t6uju","publicKey":"3u2fz3fcyblrz7nspwzkcxp7xph80h5hwu1qu4qrumrqym80r0u0.k"}
+        // "your.external.ip.goes.here:43653":{"login": "default-login", "password":"vt1ly5f4ydmm9gjk196t160z23t6uju","publicKey":"3u2fz3fcyblrz7nspwzkcxp7xph80h5hwu1qu4qrumrqym80r0u0.k"}
     ],
 ```
 Save cjdroute.conf

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -49,19 +49,19 @@ The `authorizedPasswords` section is the area where you can specify passwords to
     "authorizedPasswords":
     [
         // A unique string which is known to the client and server.
-        {"password": "zxl6zgxpl4stnuybdt0xlg4tn2cdl5h"}
+        {"password": "zxl6zgxpl4stnuybdt0xlg4tn2cdl5h", "login": "default-login"}
 
         // More passwords should look like this.
-        // {"password": "10ru8br0mhk25ccpvubv0sqnl7kuc6s"},
-        // {"password": "y68jm490dztxn3d2gvuv09bz55wqmjj"},
-        // {"password": "bnpphnq205v8nf2ksrs1fknfr572xzc"},
+        // {"password": "10ru8br0mhk25ccpvubv0sqnl7kuc6s", "login": "my-second-peer"},
+        // {"password": "y68jm490dztxn3d2gvuv09bz55wqmjj", "login": "my-third-peer"},
+        // {"password": "bnpphnq205v8nf2ksrs1fknfr572xzc", "login": "my-fourth-peer"},
 
         // These are your connection credentials
         // for people connecting to you with your default password.
         // adding more passwords for different users is advisable
         // so that leaks can be isolated.
         //
-        // "your.external.ip.goes.here:33808":{"password":"zxl6zgxpl4stnuybdt0xlg4tn2cdl5h","publicKey":"u2jf87mgqlxfzdnywp60z3tx6tkulvgh2nyc2jk1zc69zzt2s8u0.k"}
+        // "your.external.ip.goes.here:33808":{"login": "default-login", "password":"zxl6zgxpl4stnuybdt0xlg4tn2cdl5h","publicKey":"u2jf87mgqlxfzdnywp60z3tx6tkulvgh2nyc2jk1zc69zzt2s8u0.k"}
     ],
 ````
 - `password`: This is the password that another system can give to your node and be allowed to connect. You would place it in the `password` section in the next part.

--- a/doc/man/cjdroute.conf.5
+++ b/doc/man/cjdroute.conf.5
@@ -54,7 +54,7 @@ A password which can be used to peer with your node\&.
 .PP
 \fI"user":\fR "..."
 .RS 4
-An optional human-readable string that identifies what password a peer is using
+A human-readable string that identifies what password a peer is using
 on the admin interface\&. If omitted, the password will be identified by its
 position within the array (starting from 0)
 .RE
@@ -129,6 +129,7 @@ UDPInterface Example:
 "1\&.2\&.3\&.4:54321":
 .br
 {
+    "login": "login From Your Peer's authorizedPasswords",
     "password": "password From Your Peer's authorizedPasswords",
     "publicKey": "Your Peer's publicKey\&.k"
 .br
@@ -137,6 +138,7 @@ UDPInterface Example:
 "5\&.6\&.7\&.8:46321":
 .br
 {
+    "login": "cueball",
     "password": "Correct Horse Battery Staple",
     "publicKey": "Other Peer's publicKey\&.k"
 .br


### PR DESCRIPTION
As discussed on IRC.

Authentication with a login is prefered to password hash slices are not leaked.

Also, not having to support login-less authentication would make alternative implementations of CryptoAuth simpler.