### PR TITLE
Using crypto version memcmp in CryptoAuth

### DIFF
--- a/admin/Admin.c
+++ b/admin/Admin.c
@@ -239,7 +239,7 @@ static inline bool authValid(Dict* message, struct Message* messageBytes, struct
 
     crypto_hash_sha256(hash, messageBytes->bytes, messageBytes->length);
     Hex_encode(hashPtr, 64, hash, 32);
-    return Bits_memcmp(hashPtr, submittedHash->bytes, 64) == 0;
+    return Bits_constant_equal(hashPtr, submittedHash->bytes, 64) == 0;
 }
 
 static bool checkArgs(Dict* args,

--- a/admin/Admin.c
+++ b/admin/Admin.c
@@ -239,7 +239,7 @@ static inline bool authValid(Dict* message, struct Message* messageBytes, struct
 
     crypto_hash_sha256(hash, messageBytes->bytes, messageBytes->length);
     Hex_encode(hashPtr, 64, hash, 32);
-    return Bits_constant_equal(hashPtr, submittedHash->bytes, 64) == 0;
+    return Bits_constantEqual(hashPtr, submittedHash->bytes, 64) == 0;
 }
 
 static bool checkArgs(Dict* args,

--- a/crypto/CryptoAuth.c
+++ b/crypto/CryptoAuth.c
@@ -149,11 +149,11 @@ static inline struct CryptoAuth_User* getAuth(struct CryptoHeader_Challenge* aut
     for (struct CryptoAuth_User* u = ca->users; u; u = u->next) {
         count++;
         if (auth->type == 1 &&
-            !Bits_constant_equal(auth, u->passwordHash, CryptoHeader_Challenge_KEYSIZE))
+            !Bits_constantEqual(auth, u->passwordHash, CryptoHeader_Challenge_KEYSIZE))
         {
             return u;
         } else if (auth->type == 2 &&
-            !Bits_constant_equal(auth, u->userNameHash, CryptoHeader_Challenge_KEYSIZE))
+            !Bits_constantEqual(auth, u->userNameHash, CryptoHeader_Challenge_KEYSIZE))
         {
             return u;
         }
@@ -532,7 +532,7 @@ static bool ip6MatchesKey(uint8_t ip6[16], uint8_t key[32])
 {
     uint8_t calculatedIp6[16];
     AddressCalc_addressForPublicKey(calculatedIp6, key);
-    return !Bits_constant_equal(ip6, calculatedIp6, 16);
+    return !Bits_constantEqual(ip6, calculatedIp6, 16);
 }
 
 static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
@@ -553,7 +553,7 @@ static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
     // nextNonce >3: handshake complete
 
     Assert_true(knowHerKey(session));
-    if (Bits_constant_equal(session->pub.herPublicKey, header->publicKey, 32)) {
+    if (Bits_constantEqual(session->pub.herPublicKey, header->publicKey, 32)) {
         cryptoAuthDebug0(session, "DROP a packet with different public key than this session");
         return -1;
     }
@@ -665,7 +665,7 @@ static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
     // Post-decryption checking
     if (nonce == 0) {
         // A new hello packet
-        if (!Bits_constant_equal(session->herTempPubKey, header->encryptedTempKey, 32)) {
+        if (!Bits_constantEqual(session->herTempPubKey, header->encryptedTempKey, 32)) {
             // possible replay attack or duped packet
             cryptoAuthDebug0(session, "DROP dupe hello packet with same temp key");
             return -1;
@@ -674,7 +674,7 @@ static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
         // we accept a new key packet and let it change the session since the other end might have
         // killed off the session while it was in the midst of setting up.
         // This is NOT a repeat key packet because it's nonce is 2, not 3
-        if (!Bits_constant_equal(session->herTempPubKey, header->encryptedTempKey, 32)) {
+        if (!Bits_constantEqual(session->herTempPubKey, header->encryptedTempKey, 32)) {
             Assert_true(!Bits_isZero(session->herTempPubKey, 32));
             cryptoAuthDebug0(session, "DROP dupe key packet with same temp key");
             return -1;
@@ -682,7 +682,7 @@ static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
 
     } else if (nonce == 3 && session->nextNonce >= 4) {
         // Got a repeat key packet, make sure the temp key is the same as the one we know.
-        if (Bits_constant_equal(session->herTempPubKey, header->encryptedTempKey, 32)) {
+        if (Bits_constantEqual(session->herTempPubKey, header->encryptedTempKey, 32)) {
             Assert_true(!Bits_isZero(session->herTempPubKey, 32));
             cryptoAuthDebug0(session, "DROP repeat key packet with different temp key");
             return -1;
@@ -906,7 +906,7 @@ int CryptoAuth_addUser_ipv6(String* password,
     Bits_memcpy(user->passwordHash, &ac, CryptoHeader_Challenge_KEYSIZE);
 
     for (struct CryptoAuth_User* u = ca->users; u; u = u->next) {
-        if (Bits_constant_equal(user->secret, u->secret, 32)) {
+        if (Bits_constantEqual(user->secret, u->secret, 32)) {
         } else if (!login) {
         } else if (String_equals(login, u->login)) {
             Allocator_free(alloc);

--- a/crypto/CryptoAuth.c
+++ b/crypto/CryptoAuth.c
@@ -149,11 +149,11 @@ static inline struct CryptoAuth_User* getAuth(struct CryptoHeader_Challenge* aut
     for (struct CryptoAuth_User* u = ca->users; u; u = u->next) {
         count++;
         if (auth->type == 1 &&
-            !Bits_memcmp(auth, u->passwordHash, CryptoHeader_Challenge_KEYSIZE))
+            !Bits_constant_equal(auth, u->passwordHash, CryptoHeader_Challenge_KEYSIZE))
         {
             return u;
         } else if (auth->type == 2 &&
-            !Bits_memcmp(auth, u->userNameHash, CryptoHeader_Challenge_KEYSIZE))
+            !Bits_constant_equal(auth, u->userNameHash, CryptoHeader_Challenge_KEYSIZE))
         {
             return u;
         }
@@ -532,7 +532,7 @@ static bool ip6MatchesKey(uint8_t ip6[16], uint8_t key[32])
 {
     uint8_t calculatedIp6[16];
     AddressCalc_addressForPublicKey(calculatedIp6, key);
-    return !Bits_memcmp(ip6, calculatedIp6, 16);
+    return !Bits_constant_equal(ip6, calculatedIp6, 16);
 }
 
 static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
@@ -553,7 +553,7 @@ static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
     // nextNonce >3: handshake complete
 
     Assert_true(knowHerKey(session));
-    if (Bits_memcmp(session->pub.herPublicKey, header->publicKey, 32)) {
+    if (Bits_constant_equal(session->pub.herPublicKey, header->publicKey, 32)) {
         cryptoAuthDebug0(session, "DROP a packet with different public key than this session");
         return -1;
     }
@@ -665,7 +665,7 @@ static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
     // Post-decryption checking
     if (nonce == 0) {
         // A new hello packet
-        if (!Bits_memcmp(session->herTempPubKey, header->encryptedTempKey, 32)) {
+        if (!Bits_constant_equal(session->herTempPubKey, header->encryptedTempKey, 32)) {
             // possible replay attack or duped packet
             cryptoAuthDebug0(session, "DROP dupe hello packet with same temp key");
             return -1;
@@ -674,7 +674,7 @@ static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
         // we accept a new key packet and let it change the session since the other end might have
         // killed off the session while it was in the midst of setting up.
         // This is NOT a repeat key packet because it's nonce is 2, not 3
-        if (!Bits_memcmp(session->herTempPubKey, header->encryptedTempKey, 32)) {
+        if (!Bits_constant_equal(session->herTempPubKey, header->encryptedTempKey, 32)) {
             Assert_true(!Bits_isZero(session->herTempPubKey, 32));
             cryptoAuthDebug0(session, "DROP dupe key packet with same temp key");
             return -1;
@@ -682,7 +682,7 @@ static Gcc_USE_RET int decryptHandshake(struct CryptoAuth_Session_pvt* session,
 
     } else if (nonce == 3 && session->nextNonce >= 4) {
         // Got a repeat key packet, make sure the temp key is the same as the one we know.
-        if (Bits_memcmp(session->herTempPubKey, header->encryptedTempKey, 32)) {
+        if (Bits_constant_equal(session->herTempPubKey, header->encryptedTempKey, 32)) {
             Assert_true(!Bits_isZero(session->herTempPubKey, 32));
             cryptoAuthDebug0(session, "DROP repeat key packet with different temp key");
             return -1;
@@ -906,7 +906,7 @@ int CryptoAuth_addUser_ipv6(String* password,
     Bits_memcpy(user->passwordHash, &ac, CryptoHeader_Challenge_KEYSIZE);
 
     for (struct CryptoAuth_User* u = ca->users; u; u = u->next) {
-        if (Bits_memcmp(user->secret, u->secret, 32)) {
+        if (Bits_constant_equal(user->secret, u->secret, 32)) {
         } else if (!login) {
         } else if (String_equals(login, u->login)) {
             Allocator_free(alloc);

--- a/util/Bits.h
+++ b/util/Bits.h
@@ -118,6 +118,27 @@ static inline int Bits_isZero(void* buffer, size_t length)
 #define Bits_memcmp(a,b,c) __builtin_memcmp(a,b,c)
 
 /**
+ * Bits_constant_equal()
+ * Crypto version of memcmp, it is never optimized-away by a compiler and
+ * prevent timing attacks.
+ *
+ * @return 0 means equal, -1 means not equal.
+ */
+static inline int Bits_constant_equal(const void* a, const void* b, size_t len)
+{
+    size_t i;
+    const unsigned char *x = a;
+    const unsigned char *y = b;
+    unsigned char o = 0;
+
+    for (i = 0; i < len; i++) {
+        o |= x[i] ^ y[i];
+    }
+
+    return (1 & ((o - 1) >> 8)) - 1;
+}
+
+/**
  * Bits_memcpy()
  * Alias to POSIX memcpy(), allows for extra debugging checks.
  *

--- a/util/Bits.h
+++ b/util/Bits.h
@@ -135,7 +135,7 @@ static inline int Bits_constantEqual(const void* a, const void* b, size_t len)
         o |= x[i] ^ y[i];
     }
 
-    return (1 & ((o - 1) >> 8)) - 1;
+    return (o == 0) ? 0 : -1;
 }
 
 /**

--- a/util/Bits.h
+++ b/util/Bits.h
@@ -118,13 +118,13 @@ static inline int Bits_isZero(void* buffer, size_t length)
 #define Bits_memcmp(a,b,c) __builtin_memcmp(a,b,c)
 
 /**
- * Bits_constant_equal()
+ * Bits_constantEqual()
  * Crypto version of memcmp, it is never optimized-away by a compiler and
  * prevent timing attacks.
  *
  * @return 0 means equal, -1 means not equal.
  */
-static inline int Bits_constant_equal(const void* a, const void* b, size_t len)
+static inline int Bits_constantEqual(const void* a, const void* b, size_t len)
 {
     size_t i;
     const unsigned char *x = a;


### PR DESCRIPTION
As memcmp man page said:
> Do  not  use  memcmp()  to  compare  security critical data, such as cryptographic secrets, because the required CPU time depends on the number of equal bytes.  Instead, a function that performs comparisons in constant time is required.  Some operating systems provide such a function (e.g., NetBSD's consttime_memequal()), but no such function is specified in POSIX.  On Linux, it may be necessary to implement such a function oneself.