### PR TITLE
fixed build error on Linux+GCC

### DIFF
--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -437,7 +437,7 @@ static bool findBestParent0(struct Node_Two* node, struct NodeStore_pvt* store)
 
 static void findBestParent(struct Node_Two* node, struct NodeStore_pvt* store)
 {
-    uint64_t time0 = Time_hrtime(store->eventBase);
+    uint64_t time0 = Time_hrtime();
     if (!findBestParent0(node, store)) { return; }
     int ret = 0;
     int cycle = 0;


### PR DESCRIPTION
Build on Linux+GCC failed with "error: call to function ‘Time_hrtime’ without a real prototype".
