### PR TITLE
Remove dependency on KERN_ARND for OpenBSD.

### DIFF
--- a/crypto/random/seed/BsdKernArndSysctlRandomSeed.h
+++ b/crypto/random/seed/BsdKernArndSysctlRandomSeed.h
@@ -20,7 +20,7 @@
 #include "memory/Allocator.h"
 #include "util/Linker.h"
 
-#if defined(freebsd) || defined(openbsd)
+#if defined(freebsd)
     Linker_require("crypto/random/seed/BsdKernArndSysctlRandomSeed.c");
     struct RandomSeed* BsdKernArndSysctlRandomSeed_new(struct Allocator* alloc);
     RandomSeedProvider_register(BsdKernArndSysctlRandomSeed_new)


### PR DESCRIPTION
OpenBSD doesn't have KERN_ARND syscall for getting entropy unlike FreeBSD.
This commit removes dependency on it  (if I got everything right) and cjdns will be using getentropy or /dev/urandom.