### PR TITLE
Added missing close(s) to tun/tap darwin

### DIFF
--- a/util/platform/netdev/NetPlatform_darwin.c
+++ b/util/platform/netdev/NetPlatform_darwin.c
@@ -370,6 +370,7 @@ void NetPlatform_setMTU(const char* interfaceName,
        close(s);
        Except_throw(eh, "ioctl(SIOCSIFMTU) [%s]", strerror(err));
     }
+    close(s);
 }
 
 void NetPlatform_setRoutes(const char* ifName,


### PR DESCRIPTION
Seems a close was missing.
Tested on Mac OS X, it seems to work (mtu 1304, ping6 works).