### PR TITLE
Only send PEER message with known protocol version

### DIFF
--- a/net/InterfaceController.c
+++ b/net/InterfaceController.c
@@ -308,7 +308,7 @@ static void iciPing(struct InterfaceController_Iface_pvt* ici, struct InterfaceC
 
         struct Peer* ep = ici->peerMap.values[i];
 
-        if (now < ep->timeOfLastMessage + ic->pingAfterMilliseconds) {
+        if (ep->addr.protocolVersion && now < ep->timeOfLastMessage + ic->pingAfterMilliseconds) {
             // It's sending traffic so leave it alone.
 
             // wait just a minute here !


### PR DESCRIPTION
When a merged peer just finished CA but without send switch ping, I got this:

DEBUG InterfaceController.c:393 Checking for old sessions to merge with.
INFO InterfaceController.c:397 Moving endpoint to merge new session with old.
Assertion failure [InterfaceController.c:216] [(peer->addr.protocolVersion)]