### PR TITLE
Do not define getentropy shim for glibc 2.25

### DIFF
--- a/crypto/random/seed/GetEntropyRandomSeed.c
+++ b/crypto/random/seed/GetEntropyRandomSeed.c
@@ -21,7 +21,10 @@
 #include <errno.h>
 #include <sys/syscall.h>
 
-#ifndef __OPENBSD__
+#define GetEntropyRandomSeed_GLIBC_HAS_IT \
+    (defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 25))
+
+#if !defined(__OPENBSD__) && !GetEntropyRandomSeed_GLIBC_HAS_IT
 static int getentropy(void *buf, size_t buflen)
 {
     int ret;


### PR DESCRIPTION
glibc 2.25 started to define getentropy, so the build now causes a warning

    https://sourceware.org/bugzilla/show_bug.cgi?id=17252

This patch disables the shim for

- OpenBSD
- glibc >= 2.25