### PR TITLE
update ETHInterface note in configure

### DIFF
--- a/doc/configure.md
+++ b/doc/configure.md
@@ -169,7 +169,7 @@ This specifies the settings for the connection interfaces to your node. Right no
     - `bind`: This tells cjdns which device the ETHInterface should bind to. This may be different depending on your setup.
     - `connectTo`: The connectTo for the ETHInterface functions almost exactly like it does for the the UDPInterface, except instead of an IP address and a port at the beginning, it is a MAC address.
     - `beacon`: This controls peer auto-discovery. Set to 0 to disable auto-peering, 1 to use broadcast auto-peering passwords contained in "beacon" messages from other nodes, and 2 to both broadcast and accept beacons.
-    - In earlier versions of cjdns, it was necessary to uncomment the ETHInterface if you want to use it, however, now it is uncommented by default in the `crashey` branch which will eventually be merged to master.
+    - In earlier versions of cjdns, it was necessary to uncomment the ETHInterface if you want to use it, however, now it is uncommented by default.
 
 Router
 ------


### PR DESCRIPTION
Looks like the uncommented ETHInterface has since been merged to master:
```
cjdroute --genconf | grep \"ETH
        "ETHInterface":
```