### PR TITLE
Allocator has critical bug when handle the adopt memory.

### DIFF
--- a/memory/Allocator.c
+++ b/memory/Allocator.c
@@ -727,7 +727,7 @@ void Allocator__adopt(struct Allocator* adoptedParent,
     parent->adoptions->children = pl;
 
     struct Allocator_List* cl =
-        Allocator__calloc(childToAdopt, sizeof(struct Allocator_List), 1, file, line);
+        Allocator__calloc(adoptedParent, sizeof(struct Allocator_List), 1, file, line);
     cl->alloc = parent;
     cl->next = child->adoptions->parents;
     child->adoptions->parents = cl;


### PR DESCRIPTION
When using ./tools/search -c 20 xxx.xxx.xxx.xxx, It will trigger a critical segment fault. The patch is only fix some typo but not the segfault.
Detail panic info is at https://cryptpad.fr/code/#/1/view/D4rWFrXx4okjJ9w9Mc6oEQ/gUyqo2zKgrd3WRLlmCpEKuYBmOciJOU3F8JlSpAKJjw