### PR TITLE
update node

### DIFF
--- a/doc/install/raspbian-jessie.md
+++ b/doc/install/raspbian-jessie.md
@@ -12,12 +12,25 @@ sudo apt install nodejs build-essential git-svn
 
 ```bash
 sudo -i
+
+# Upgrade Node the official way
+# https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions
+curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+apt install -y nodejs
+
+# Build cjdns
 cd /opt
 git clone https://github.com/cjdelisle/cjdns.git
 cd cjdns
 NO_TEST=1 Seccomp_NO=1 ./do
 ln -s /opt/cjdns/cjdroute /usr/bin
+
+# Generate a config file
 (umask 077 && ./cjdroute --genconf > /etc/cjdroute.conf)
+# Regarding cjdns' configuration you can continue reading here:
+# https://github.com/cjdelisle/cjdns#2-find-a-friend
+
+# Set up a system service that runs on startup
 cp contrib/systemd/cjdns.service /etc/systemd/system/
 systemctl enable cjdns
 systemctl start cjdns


### PR DESCRIPTION
The version that's in the jessie repos is too old (v0.10.29). So I added the installation instructions for another deb source as pointed out in the [official documentation](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions).