### PR TITLE
possible fix when x-compiling

### DIFF
--- a/crypto/random/seed/GetEntropyRandomSeed.c
+++ b/crypto/random/seed/GetEntropyRandomSeed.c
@@ -21,10 +21,10 @@
 #include <errno.h>
 #include <sys/syscall.h>
 
-#define GetEntropyRandomSeed_GLIBC_HAS_IT \
-    (defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ))
-
-#if !defined(__OPENBSD__) && !GetEntropyRandomSeed_GLIBC_HAS_IT
+#if !defined(__OPENBSD__) && \
+    (!defined(__GNU_LIBRARY__) || !defined(__GLIBC__) || \
+    !defined(__GLIBC_MINOR__) || __GLIBC__ < 2 || \
+    (__GLIBC__ == 2 && __GLIBC_MINOR__ < 25))
 static int getentropy(void *buf, size_t buflen)
 {
     int ret;


### PR DESCRIPTION
gcc: 6.3.0
musl: 1.1.16

was compiling x86_64 w/ musl (not uclibc)
is this sane? i think the logic needs fixup here. build finishes w/o errors.


```
crypto/random/seed/GetEntropyRandomSeed.c:25:75: error: missing binary operator before token "("
     (defined(__GNU_LIBRARY__) && defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 25))
                                                                           ^
crypto/random/seed/GetEntropyRandomSeed.c:27:31: note: in expansion of macro 'GetEntropyRandomSeed_GLIBC_HAS_IT'
 #if !defined(__OPENBSD__) && !GetEntropyRandomSeed_GLIBC_HAS_IT
                               ^
``` 
