### PR TITLE
Remove prefix length redundancy.

### DIFF
--- a/util/platform/netdev/NetDev.c
+++ b/util/platform/netdev/NetDev.c
@@ -59,8 +59,8 @@ void NetDev_addAddress(const char* ifName,
 
     checkAddressAndPrefix(sa, &addrFam, &printedAddr, &addr, alloc, eh);
 
-    Log_info(logger, "Setting IP address [%s/%d] on interface [%s]",
-             printedAddr, sa->prefix, ifName);
+    Log_info(logger, "Setting IP address [%s] on interface [%s]",
+             printedAddr, ifName);
 
     NetPlatform_addAddress(ifName, addr, sa->prefix, addrFam, logger, alloc, eh);
 }


### PR DESCRIPTION
eg. it prints this:

```
INFO NetDev.c:63 Setting IP address [fcb9:326d:37d5:c57b:7ee5:28b5:7aa5:525/8/8] on interface [tun0]
```