### PR TITLE
grammar fix

### DIFF
--- a/subnode/readme.md
+++ b/subnode/readme.md
@@ -1,8 +1,8 @@
 # Cjdns subnode
 
 This is the part which communicates with the cjdns supernode. It fulfills the Pathfinder protocol
-internally to cjdns and it answers the questions asked to it by querying it's supernode(s).
+internally to cjdns and it answers the questions asked to it by querying its supernode(s).
 
-In order to discover it's supernode(s), it will send findNode (`fn`) queries to it's peers.
-Any findNode queries which are sent to this node will be forwarded to it's supernode and the answers
+In order to discover its supernode(s), it will send findNode (`fn`) queries to its peers.
+Any findNode queries which are sent to this node will be forwarded to its supernode and the answers
 forwarded back.


### PR DESCRIPTION
"it's" (it is) used incorrectly, should be "its"