### PR TITLE
missing quotes in do and node_build/node.sh

### DIFF
--- a/do
+++ b/do
@@ -1,2 +1,2 @@
 #!/bin/sh
-MAINJS=./node_build/make.js ./node_build/node.sh $@
+MAINJS=./node_build/make.js ./node_build/node.sh "$@"

--- a/node_build/node.sh
+++ b/node_build/node.sh
@@ -30,8 +30,8 @@ die () { printf '%s\n' "ERROR: $1" >&2; exit 100; }
 [ "$GREP_PATH" != "" ] || GREP_PATH=$(command -v grep) || die "missing grep";
 
 
-[ "$PLATFORM" != "" ] || PLATFORM=$($UNAME_PATH | $TR_PATH '[:upper:]' '[:lower:]')
-[ "$MARCH" != "" ] || MARCH=$($UNAME_PATH -m | $SED_PATH 's/i./x/g')
+[ "$PLATFORM" != "" ] || PLATFORM=$("$UNAME_PATH" | "$TR_PATH" '[:upper:]' '[:lower:]')
+[ "$MARCH" != "" ] || MARCH=$("$UNAME_PATH" -m | "$SED_PATH" 's/i./x/g')
 DEFAULT_NODEDIR="node_$PLATFORM"
 
 usage () {
@@ -52,7 +52,7 @@ usage () {
     printf "\nOverrides: (for overriding default detection)"
     printf "PLATFORM    The name of the system in lowercase (e.g. linux darwin freebsd)\n"
     printf "MARCH       The architecture of the processor (e.g. x86 x86_64 armv7l)\n"
-    printf "SED_PATH    The path to a working sed sed implementation\n"
+    printf "SED_PATH    The path to a working sed implementation\n"
     printf "TR_PATH     The path to a working tr implementation\n"
     printf "UNAME_PATH  The path to a working uname implementation\n"
     exit 0;
@@ -100,7 +100,7 @@ getSha() {
     expected_sum='01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b'
     for shasum_tool in 'sha256sum' 'gsha256sum' 'sha256' 'shasum -a 256' 'openssl sha256'; do
         cmdExists "$shasum_tool" || continue;
-        printf '\n' | $shasum_tool | $GREP_PATH -q "$expected_sum" && {
+        printf '\n' | $shasum_tool | "$GREP_PATH" -q "$expected_sum" && {
             shasum_cmd="$shasum_tool"
             return 0
         }
@@ -121,8 +121,8 @@ getNode() {
         "Please install nodejs (>= $MINVER) from your distribution package repository or source" \
         && die "";
 
-    [ -d "$NODEDIR/nodejs" ] && $RM_PATH -r "$NODEDIR/nodejs"
-    $INSTALL_PATH -d "$NODEDIR/nodejs"
+    [ -d "$NODEDIR/nodejs" ] && "$RM_PATH" -r "$NODEDIR/nodejs"
+    "$INSTALL_PATH" -d "$NODEDIR/nodejs"
 
     cd "$NODEDIR/nodejs"
     node_dl="node-${DLVER}.tar.gz"
@@ -142,13 +142,13 @@ getNode() {
     printf '%s\n' 'DONE!'
 
     printf '%s %s ' '==>' "Verifying the checksum of the downloaded archive..."
-    $shasum_cmd "$node_dl" | $GREP_PATH -q "$NODEHASH" \
+    $shasum_cmd "$node_dl" | "$GREP_PATH" -q "$NODEHASH" \
         || die 'The downloaded file is damaged! Aborting'
     printf '%s\n' 'DONE!'
 
     printf '%s %s ' '==>' "Extracting the downloaded archive..."
-    $INSTALL_PATH -d node
-    $TAR_PATH xzf "$node_dl" -C node --strip-components=1
+    "$INSTALL_PATH" -d node
+    "$TAR_PATH" xzf "$node_dl" -C node --strip-components=1
     [ -d 'node' ] || die 'An error prevented the archive from being extracted'
     printf '%s\n\n' 'DONE!'
     cd ../../
@@ -158,7 +158,7 @@ getNode() {
 }
 
 main() {
-    [ -d "$NODEDIR" ] || $INSTALL_PATH -d "$NODEDIR" || die "failed to create node dir $NODEDIR"
+    [ -d "$NODEDIR" ] || "$INSTALL_PATH" -d "$NODEDIR" || die "failed to create node dir $NODEDIR"
     getSha || die "couldn't find working sha256 implementation";
     checkNode || getNode || die "couldn't get working node.js implementation";
     "$node_cmd" $MAINJS "$@"


### PR DESCRIPTION
Some missing (but important) quotes for some variables.
For example, if I have a space in one of the directories of my `PATH`, the interpolation of `*_PATH` variables won't give the expected results.

For now, the script is simple, but you may have more problems later if you require a more advanced usage from the `openssl *` commands (Bash's arrays could be useful if you encounter such problems, but you'll loose some portability).

For `$@` in `do`, unquoted `$@` isn't what you want most of the time as it will mess with spaces.

The script says to check https://github.com/cjdelisle/node.sh for updates but commit 464ad91 was directly merged in this repository so I am not sure if this is the preferred way to submit this small patch.
