### PR TITLE
Configurable prefix

### DIFF
--- a/admin/angel/Core.c
+++ b/admin/angel/Core.c
@@ -210,7 +210,7 @@ static void initTunnel(Dict* args, void* vcontext, String* txid, struct Allocato
     struct Jmp jmp;
     Jmp_try(jmp) {
         String* desiredName = Dict_getStringC(args, "desiredTunName");
-        initTunnel2(desiredName, ctx, 8, &jmp.handler);
+        initTunnel2(desiredName, ctx, AddressCalc_ADDRESS_PREFIX_BITS, &jmp.handler);
     } Jmp_catch {
         String* error = String_printf(requestAlloc, "Failed to configure tunnel [%s]", jmp.message);
         sendResponse(error, ctx->admin, txid, requestAlloc);

--- a/contrib/c/privatetopublic.c
+++ b/contrib/c/privatetopublic.c
@@ -70,8 +70,7 @@ int main(int argc, char** argv)
 
     Hex_decode(privateKey, 32, privateKeyHexIn, 65);
     crypto_scalarmult_curve25519_base(address.key, privateKey);
-    AddressCalc_addressForPublicKey(address.ip6.bytes, address.key);
-    if (address.ip6.bytes[0] == 0xFC) {
+    if (AddressCalc_addressForPublicKey(address.ip6.bytes, address.key)) {
         Base32_encode(publicKeyBase32Out, 53, address.key, 32);
         Address_printShortIp(addressOut, &address);
         printf(    "Input privkey: %s\n"

--- a/crypto/AddressCalc.c
+++ b/crypto/AddressCalc.c
@@ -14,15 +14,40 @@
  */
 #include "crypto_hash_sha512.h"
 #include "util/Bits.h"
+#include "crypto/AddressCalc.h"
 
 #include <stdint.h>
+#include <stdbool.h>
 
-int AddressCalc_validAddress(const uint8_t address[16])
+#ifndef ADDRESS_PREFIX
+#define ADDRESS_PREFIX 0xfc
+#endif
+#ifndef ADDRESS_PREFIX_BYTES
+#define ADDRESS_PREFIX_BYTES 1
+#endif
+
+bool AddressCalc_validAddress(const uint8_t address[16])
 {
-    return address[0] == 0xFC;
+    int mask = ADDRESS_PREFIX;
+    for (int8_t i=ADDRESS_PREFIX_BYTES-1; i>=0; i--) {
+        if (address[i] != (mask & 0xff)) {
+            return false;
+        }
+        mask >>= 8;
+    }
+    return true;
 }
 
-int AddressCalc_addressForPublicKey(uint8_t addressOut[16], const uint8_t key[32])
+void AddressCalc_makeValidAddress(uint8_t address[16])
+{
+    int mask = ADDRESS_PREFIX;
+    for (int8_t i=ADDRESS_PREFIX_BYTES-1; i>=0; i--) {
+        address[i] = mask & 0xff;
+        mask >>= 8;
+    }
+}
+
+bool AddressCalc_addressForPublicKey(uint8_t addressOut[16], const uint8_t key[32])
 {
     uint8_t hash[crypto_hash_sha512_BYTES];
     crypto_hash_sha512(hash, key, 32);

--- a/crypto/AddressCalc.h
+++ b/crypto/AddressCalc.h
@@ -21,6 +21,27 @@ Linker_require("crypto/AddressCalc.c");
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef ADDRESS_PREFIX
+#define AddressCalc_ADDRESS_PREFIX ADDRESS_PREFIX
+#else
+#define AddressCalc_ADDRESS_PREFIX 0xfc
+#endif
+#ifdef ADDRESS_PREFIX_BITS
+#define AddressCalc_ADDRESS_PREFIX_BITS ADDRESS_PREFIX_BITS
+#else
+#define AddressCalc_ADDRESS_PREFIX_BITS 8
+#endif
+
+#if AddressCalc_ADDRESS_PREFIX_BITS > 64
+#error "ADDRESS_PREFIX_BITS may not be > 64."
+#endif
+#if AddressCalc_ADDRESS_PREFIX_BITS <= 0
+#error "ADDRESS_PREFIX_BITS may not be <= 0."
+#endif
+#if AddressCalc_ADDRESS_PREFIX >= (1 << AddressCalc_ADDRESS_PREFIX_BITS)
+#error "ADDRESS_PREFIX may not be >= 2^ADDRESS_PREFIX_BITS."
+#endif
+
 /**
  * Check if an address is valid given the IPv6
  *

--- a/crypto/AddressCalc.h
+++ b/crypto/AddressCalc.h
@@ -30,10 +30,17 @@ Linker_require("crypto/AddressCalc.c");
 bool AddressCalc_validAddress(const uint8_t address[16]);
 
 /**
+ * Edits the prefix of the given address to make it a valid cjdns address.
+ */
+
+void AddressCalc_makeValidAddress(uint8_t address[16]);
+
+/**
  * Calculate a cjdns IPv6 address for a public key.
  *
  * @param addressOut put the address here.
  * @param key the 256 bit curve25519 public key.
+ * @return true if the IPv6 is a valid cjdns address.
  */
 bool AddressCalc_addressForPublicKey(uint8_t addressOut[16], const uint8_t key[32]);
 

--- a/debian/do-wrapper
+++ b/debian/do-wrapper
@@ -11,6 +11,9 @@ if [[ "${DEB_BUILD_OPTIONS}" =~ nocheck ]]; then
     export NO_TEST=1
 fi
 
+export ADDRESS_PREFIX="${DEB_ADDRESS_PREFIX}"
+export ADDRESS_PREFIX_BITS="${DEB_ADDRESS_PREFIX_BITS}"
+
 # Unset CFLAGS set by debhelper to fix a number of issues.
 # It usually contains something like this:
 # -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security

--- a/dht/Pathfinder.c
+++ b/dht/Pathfinder.c
@@ -12,6 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "crypto/AddressCalc.h"
 #include "dht/Pathfinder.h"
 #include "dht/DHTModule.h"
 #include "dht/Address.h"
@@ -87,7 +88,7 @@ static int incomingFromDHT(struct DHTMessage* dmessage, void* vpf)
     }
 
     // Sanity check (make sure the addr was actually calculated)
-    Assert_true(addr->ip6.bytes[0] == 0xfc);
+    Assert_true(AddressCalc_validAddress(addr->ip6.bytes));
 
     Message_shift(msg, PFChan_Msg_MIN_SIZE, NULL);
     struct PFChan_Msg* emsg = (struct PFChan_Msg*) msg->bytes;

--- a/dht/dhtcore/Janitor.c
+++ b/dht/dhtcore/Janitor.c
@@ -12,6 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "crypto/AddressCalc.h"
 #include "crypto/random/Random.h"
 #include "dht/Address.h"
 #include "dht/dhtcore/Janitor.h"
@@ -645,7 +646,7 @@ static void maintanenceCycle(void* vcontext)
     // random search
     Random_bytes(janitor->rand, addr.ip6.bytes, 16);
     // Make this a valid address.
-    addr.ip6.bytes[0] = 0xfc;
+    AddressCalc_makeValidAddress(addr.ip6.bytes);
 
     struct Node_Two* n = NodeStore_getBest(janitor->nodeStore, addr.ip6.bytes);
 

--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -1612,6 +1612,8 @@ struct NodeStore* NodeStore_new(struct Address* myAddress,
 
     // Create the self node
     struct Node_Two* selfNode = Allocator_calloc(alloc, sizeof(struct Node_Two), 1);
+    Assert_true(selfNode);
+    Assert_true(myAddress);
     Bits_memcpy(&selfNode->address, myAddress, sizeof(struct Address));
     selfNode->encodingScheme = NumberCompress_defineScheme(alloc);
     selfNode->alloc = alloc;

--- a/dht/dhtcore/test/NodeStore_test.c
+++ b/dht/dhtcore/test/NodeStore_test.c
@@ -24,6 +24,24 @@
 #include "util/Base32.h"
 #include "util/log/FileWriterLog.h"
 
+static uint8_t* ADDRS[] = {
+    "v13.0000.0000.0000.001f.usclqxtgkksmgwv10h8h3pltm3zy27bddb20mpsbrvjlcw4d9gl0.k",
+    "v13.0000.0000.0000.001b.03ws4vngbq56ymd14vbpd92zdfr0783t7g6u3k4dtb1kuw5m62v0.k",
+    "v13.0000.0000.0000.0019.8u2pvwuf1wmf5hwxytckbk4sbyrg3rdnqdwulbgsbmw408grm500.k",
+    "v13.0000.0000.0000.0017.bf39dq2mubq17x2lmz8cwgr839s95b6gk7dmcty22uw3dj7v5zy0.k",
+    "v13.0000.0000.0000.0015.q402jm870c215kdvf4wy2qvpt4kdrx0b4zyx2vnv2fdfprf41fk0.k",
+    "v13.0000.0000.0000.0013.6npk9pfdw09t0ldp0c9usrp8pkhttg0104849ng6j5gsz3w8q3x0.k",
+    "v13.0000.0000.0000.00b6.t9lpkc69nwpxpnusc7nlgrrjmzdcjhgf52zhhr9k69t9x6hrz5c0.k",
+    "v13.0000.0000.0000.00b2.05t007gun13qnhm5czlkjlp14lpr2v2j6f4g6bmzgbwv5mj9uy60.k",
+    "v13.0000.0000.0000.00ae.f5d1l67lb3dl7z41l1lwmh0jsptq382vsyvr999brjdjqutj5m90.k",
+    "v13.0000.0000.0000.00aa.61jw1hdru3tnwv3vfpt9vmmbvyhfxc8chd9msf1jhumq2y3h5pn0.k",
+    "v13.0000.0000.0000.00a2.684v75l5czfvgmr5qkb60xd7d9l79zxg5nyj5wmbhr8nxm7wzn20.k",
+    "v13.0000.0000.0000.009e.th3p5791z6xr24plc3487xfb9tfy4n7n51y8pbhnr9771kluhr10.k",
+    "v13.0000.0000.0000.00ba.d40x5rkb8jj5v1521j5l6wd1pu7svzrmyb2kvf1rj7ll0kuydt40.k",
+    "v13.0000.0000.0000.001d.rujhjmq178wtfxccuwp3h17uq7u7phfr1t1m1zn80855h2wngl50.k",
+    "v13.0000.0000.0000.00a6.0czm5qrryjrhc4dv9zcl148pnbur1869zufrcfw8f9b7vw132yu0.k",
+    NULL
+};
 
 static void addNode(struct NodeStore* ns, uint8_t* address, struct Allocator* alloc)
 {
@@ -31,7 +49,6 @@ static void addNode(struct NodeStore* ns, uint8_t* address, struct Allocator* al
     struct Address* addr = Address_fromString(String_new(address, alloc), alloc);
     Assert_true(NodeStore_discoverNode(ns, addr, scheme, 0, 100));
 }
-
 
 static void checkList(struct NodeList* list,
                       uint64_t* expectedOutputs,
@@ -55,7 +72,7 @@ static void genAddress(uint8_t* addr, struct Random* rand)
     uint8_t ip[16];
     uint8_t privateKey[32];
     Key_gen(ip, publicKey, privateKey, rand);
-    uint8_t* publicKeyBase32 = CString_strstr(addr, "X");
+    uint8_t* publicKeyBase32 = &addr[24];
     Assert_true(publicKeyBase32);
     Base32_encode(publicKeyBase32, 53, publicKey, 32);
     publicKeyBase32[52] = '.';
@@ -97,37 +114,20 @@ int main(int argc, char** argv)
     struct EventBase* base = EventBase_new(alloc);
     struct Random* rand = Random_new(alloc, NULL, NULL);
 
-    uint8_t* addrs[] = {
-        "v13.0000.0000.0000.001f.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.001b.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.0019.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.0017.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.0015.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.0013.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.00b6.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.00b2.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.00ae.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.00aa.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.00a2.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.009e.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.00ba.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.001d.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        "v13.0000.0000.0000.00a6.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.k",
-        NULL
-    };
-
+#if defined(ADDRESS_PREFIX) || defined(ADDRESS_PREFIX_BITS)
     // Make all addresses writeable
-    for (uint8_t** addr = addrs; *addr; addr++) {
+    for (uint8_t** addr = ADDRS; *addr; addr++) {
         char *addr_rw = Allocator_malloc(alloc, 79);
         Bits_memcpy(addr_rw, *addr, 79);
         *addr = addr_rw;
     }
 
-    for (uint8_t** addr = addrs; *addr; addr++) {
+    for (uint8_t** addr = ADDRS; *addr; addr++) {
         genAddress(*addr, rand);
     }
+#endif
 
-    getPeersTest(addrs, base, logger, alloc, rand);
+    getPeersTest(ADDRS, base, logger, alloc, rand);
 
     Allocator_free(alloc);
     return 0;

--- a/interface/tuntap/windows/test/TAPInterface_root_test.c
+++ b/interface/tuntap/windows/test/TAPInterface_root_test.c
@@ -18,6 +18,7 @@ int main(int argc, char** argv)
     return 0;
 }
 #else
+#include "crypto/AddressCalc.h"
 #include "interface/tuntap/windows/NDPServer.h"
 #include "exception/Except.h"
 #include "memory/Allocator.h"
@@ -112,11 +113,11 @@ printf("init test");
     ndp->generic.receiveMessage = receiveMessage;
     ndp->generic.receiverContext = alloc;
     ndp->advertisePrefix[0] = 0xfd;
-    ndp->prefixLen = 8;
+    ndp->prefixLen = AddressCalc_ADDRESS_PREFIX_BITS;
 
     struct Sockaddr_storage ss;
     Assert_true(!Sockaddr_parse("fd00::1", &ss));
-    NetDev_addAddress(ifName, &ss.addr, 8, logger, NULL);
+    NetDev_addAddress(ifName, &ss.addr, AddressCalc_ADDRESS_PREFIX_BITS, logger, NULL);
 
     Timeout_setTimeout(fail, alloc, 10000, base, alloc);
 

--- a/net/InterfaceController.c
+++ b/net/InterfaceController.c
@@ -556,7 +556,8 @@ static Iface_DEFUN handleBeacon(struct Message* msg, struct InterfaceController_
         printedAddr = Address_toString(&addr, msg->alloc);
     }
 
-    if (addr.ip6.bytes[0] != 0xfc || !Bits_memcmp(ic->ca->publicKey, addr.key, 32)) {
+    if (!AddressCalc_validAddress(addr.ip6.bytes)
+        || !Bits_memcmp(ic->ca->publicKey, addr.key, 32)) {
         Log_debug(ic->logger, "handleBeacon invalid key [%s]", printedAddr->bytes);
         return NULL;
     }

--- a/net/SessionManager.c
+++ b/net/SessionManager.c
@@ -206,7 +206,7 @@ static struct SessionManager_Session_pvt* getSession(struct SessionManager_pvt* 
                                                      uint64_t label,
                                                      uint32_t metric)
 {
-    Assert_true(ip6[0] == 0xfc);
+    Assert_true(AddressCalc_validAddress(ip6));
     struct SessionManager_Session_pvt* sess = sessionForIp6(ip6, sm);
     if (sess) {
         sess->pub.version = (sess->pub.version) ? sess->pub.version : version;

--- a/net/UpperDistributor.c
+++ b/net/UpperDistributor.c
@@ -12,6 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "crypto/AddressCalc.h"
 #include "dht/Address.h"
 #include "interface/Iface.h"
 #include "memory/Allocator.h"
@@ -67,7 +68,8 @@ static Iface_DEFUN fromHandler(struct Message* msg, struct UpperDistributor_pvt*
         Log_debug(ud->log, "DROP runt");
         return NULL;
     }
-    uint8_t srcAndDest[32] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0xfc,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
+    uint8_t srcAndDest[32] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
+    AddressCalc_makeValidAddress(&srcAndDest[16]);
     Bits_memcpy(srcAndDest, ud->myAddress->ip6.bytes, 16);
     struct Headers_UDPHeader* udp = (struct Headers_UDPHeader*) msg->bytes;
     if (Checksum_udpIp6(srcAndDest, msg->bytes, msg->length)) {
@@ -118,7 +120,8 @@ static void sendToHandlers(struct Message* msg,
             udpH.length_be = Endian_hostToBigEndian16(cmsg->length + Headers_UDPHeader_SIZE);
             udpH.checksum_be = 0;
             Message_push(cmsg, &udpH, Headers_UDPHeader_SIZE, NULL);
-            uint8_t srcAndDest[32] = {0xfc,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
+            uint8_t srcAndDest[32] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
+            AddressCalc_makeValidAddress(srcAndDest);
             Bits_memcpy(&srcAndDest[16], ud->myAddress->ip6.bytes, 16);
             uint16_t checksum = Checksum_udpIp6(srcAndDest, cmsg->bytes, cmsg->length);
             ((struct Headers_UDPHeader*)cmsg->bytes)->checksum_be = checksum;
@@ -132,8 +135,9 @@ static void sendToHandlers(struct Message* msg,
         {
             struct RouteHeader rh = {
                 .version_be = Endian_hostToBigEndian32(Version_CURRENT_PROTOCOL),
-                .ip6 = {0xfc,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1}
+                .ip6 = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1}
             };
+            AddressCalc_makeValidAddress(rh.ip6);
             Message_push(cmsg, &rh, RouteHeader_SIZE, NULL);
         }
 
@@ -169,7 +173,9 @@ static Iface_DEFUN incomingFromTunAdapterIf(struct Message* msg, struct Iface* t
         Identity_containerOf(tunAdapterIf, struct UpperDistributor_pvt, pub.tunAdapterIf);
     struct RouteHeader* rh = (struct RouteHeader*) msg->bytes;
     Assert_true(msg->length >= RouteHeader_SIZE);
-    if (!Bits_memcmp(rh->ip6, "\xfc\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1", 16)) {
+    uint8_t expected_ip6[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
+    AddressCalc_makeValidAddress(expected_ip6);
+    if (!Bits_memcmp(rh->ip6, expected_ip6, 16)) {
         return fromHandler(msg, ud);
     }
     return toSessionManagerIf(msg, ud);

--- a/node_build/make.js
+++ b/node_build/make.js
@@ -91,6 +91,13 @@ Builder.configure({
         builder.config.cflags.push('-D', 'TESTING=1');
     }
 
+    if (process.env['ADDRESS_PREFIX'] != undefined) {
+        builder.config.cflags.push('-D', 'ADDRESS_PREFIX=' + process.env['ADDRESS_PREFIX']);
+    }
+    if (process.env['ADDRESS_PREFIX_BITS'] != undefined) {
+        builder.config.cflags.push('-D', 'ADDRESS_PREFIX_BITS=' + process.env['ADDRESS_PREFIX_BITS']);
+    }
+
     if (!builder.config.crossCompiling) {
         if (NO_MARCH_FLAG.indexOf(process.arch) < -1) {
             builder.config.cflags.push('-march=native');

--- a/node_build/make.js
+++ b/node_build/make.js
@@ -91,10 +91,10 @@ Builder.configure({
         builder.config.cflags.push('-D', 'TESTING=1');
     }
 
-    if (process.env['ADDRESS_PREFIX'] != undefined) {
+    if (process.env['ADDRESS_PREFIX'] !== undefined) {
         builder.config.cflags.push('-D', 'ADDRESS_PREFIX=' + process.env['ADDRESS_PREFIX']);
     }
-    if (process.env['ADDRESS_PREFIX_BITS'] != undefined) {
+    if (process.env['ADDRESS_PREFIX_BITS'] !== undefined) {
         builder.config.cflags.push('-D', 'ADDRESS_PREFIX_BITS=' + process.env['ADDRESS_PREFIX_BITS']);
     }
 

--- a/subnode/MsgCore.c
+++ b/subnode/MsgCore.c
@@ -13,6 +13,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "benc/Dict.h"
+#include "crypto/AddressCalc.h"
 #include "memory/Allocator.h"
 #include "dht/Address.h"
 #include "dht/CJDHTConstants.h"
@@ -154,7 +155,7 @@ static void sendMsg(struct MsgCore_pvt* mcp,
     //Log_debug(mcp->log, "Sending msg [%s]", Escape_getEscaped(msg->bytes, msg->length, alloc));
 
     // Sanity check (make sure the addr was actually calculated)
-    Assert_true(addr->ip6.bytes[0] == 0xfc);
+    Assert_true(AddressCalc_validAddress(addr->ip6.bytes));
 
     struct DataHeader data;
     Bits_memset(&data, 0, sizeof(struct DataHeader));

--- a/subnode/ReachabilityAnnouncer.c
+++ b/subnode/ReachabilityAnnouncer.c
@@ -17,6 +17,7 @@
 #include "util/Identity.h"
 #include "util/events/Time.h"
 #include "wire/Announce.h"
+#include "crypto/AddressCalc.h"
 #include "crypto/Sign.h"
 #include "util/AddrTools.h"
 
@@ -616,7 +617,7 @@ static void onAnnounceCycle(void* vRap)
 
     struct Query* q = Allocator_calloc(qp->alloc, sizeof(struct Query), 1);
     q->rap = rap;
-    Assert_true(rap->snode.ip6.bytes[0] == 0xfc);
+    Assert_true(AddressCalc_validAddress(rap->snode.ip6.bytes));
     Bits_memcpy(&q->target, &rap->snode, Address_SIZE);
     qp->userData = q;
 

--- a/subnode/ReachabilityCollector.c
+++ b/subnode/ReachabilityCollector.c
@@ -12,6 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "crypto/AddressCalc.h"
 #include "dht/dhtcore/ReplySerializer.h"
 #include "subnode/ReachabilityCollector.h"
 #include "util/log/Log.h"
@@ -171,7 +172,7 @@ static void mkNextRequest(struct ReachabilityCollector_pvt* rcp)
         MsgCore_createQuery(rcp->msgCore, TIMEOUT_MILLISECONDS, rcp->alloc);
     query->userData = rcp;
     query->cb = onReply;
-    Assert_true(pi->pub.addr.ip6.bytes[0] == 0xfc);
+    Assert_true(AddressCalc_validAddress(pi->pub.addr.ip6.bytes));
     query->target = Address_clone(&pi->pub.addr, query->alloc);
     Dict* d = query->msg = Dict_new(query->alloc);
     Dict_putStringCC(d, "q", "gp", query->alloc);

--- a/subnode/SubnodePathfinder.c
+++ b/subnode/SubnodePathfinder.c
@@ -20,6 +20,7 @@
 #include "subnode/PingResponder.h"
 #include "subnode/BoilerplateResponder.h"
 #include "subnode/ReachabilityCollector.h"
+#include "crypto/AddressCalc.h"
 #include "dht/Address.h"
 #include "wire/DataHeader.h"
 #include "wire/RouteHeader.h"
@@ -189,7 +190,7 @@ static Iface_DEFUN searchReq(struct Message* msg, struct SubnodePathfinder_pvt* 
     qp->cb = getRouteReply;
     qp->userData = pf;
 
-    Assert_true(pf->pub.snh->snodeAddr.ip6.bytes[0] == 0xfc);
+    Assert_true(AddressCalc_validAddress(pf->pub.snh->snodeAddr.ip6.bytes));
     qp->target = &pf->pub.snh->snodeAddr;
 
     Log_debug(pf->log, "Sending getRoute to snode %s",
@@ -354,7 +355,7 @@ static Iface_DEFUN unsetupSession(struct Message* msg, struct SubnodePathfinder_
     qp->cb = unsetupSessionPingReply;
     qp->userData = pf;
 
-    Assert_true(addr.ip6.bytes[0] == 0xfc);
+    Assert_true(AddressCalc_validAddress(addr.ip6.bytes));
     Assert_true(addr.path);
     qp->target = Address_clone(&addr, qp->alloc);
 

--- a/subnode/SupernodeHunter.c
+++ b/subnode/SupernodeHunter.c
@@ -12,6 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "crypto/AddressCalc.h"
 #include "crypto/Key.h"
 #include "dht/dhtcore/ReplySerializer.h"
 #include "subnode/SupernodeHunter.h"
@@ -168,7 +169,7 @@ static void adoptSupernode(struct SupernodeHunter_pvt* snp, struct Address* cand
     Log_debug(snp->log, "Pinging snode [%s]", Address_toString(qp->target, qp->alloc)->bytes);
     Dict_putStringCC(msg, "sq", "pn", qp->alloc);
 
-    Assert_true(candidate->ip6.bytes[0] == 0xfc);
+    Assert_true(AddressCalc_validAddress(candidate->ip6.bytes));
     return;
 }
 

--- a/test/Beacon_test.c
+++ b/test/Beacon_test.c
@@ -136,6 +136,8 @@ static void start(struct Allocator* alloc,
                   struct Random* rand,
                   RunTest* runTest)
 {
+
+#if defined(ADDRESS_PREFIX) || defined(ADDRESS_PREFIX_BITS)
     uint8_t address[16];
     uint8_t publicKey[32];
     uint8_t privateKeyA[32];
@@ -147,6 +149,21 @@ static void start(struct Allocator* alloc,
     Key_gen(address, publicKey, privateKeyB, rand);
     struct TestFramework* b =
         TestFramework_setUp((char*) privateKeyB, alloc, base, rand, logger);
+#else
+     struct TestFramework* a =
+        TestFramework_setUp("\xad\x7e\xa3\x26\xaa\x01\x94\x0a\x25\xbc\x9e\x01\x26\x22\xdb\x69"
+                            "\x4f\xd9\xb4\x17\x7c\xf3\xf8\x91\x16\xf3\xcf\xe8\x5c\x80\xe1\x4a",
+                            alloc, base, rand, logger);
+    //"publicKey": "kmzm4w0kj9bswd5qmx74nu7kusv5pj40vcsmp781j6xxgpd59z00.k",
+    //"ipv6": "fc41:94b5:0925:7ba9:3959:11ab:a006:367a",
+
+    struct TestFramework* b =
+        TestFramework_setUp("\xd8\x54\x3e\x70\xb9\xae\x7c\x41\xbc\x18\xa4\x9a\x9c\xee\xca\x9c"
+                            "\xdc\x45\x01\x96\x6b\xbd\x7e\x76\xcf\x3a\x9f\xbc\x12\xed\x8b\xb4",
+                            alloc, base, rand, logger);
+    //"publicKey": "vz21tg07061s8v9mckrvgtfds7j2u5lst8cwl6nqhp81njrh5wg0.k",
+    //"ipv6": "fc1f:5b96:e1c5:625d:afde:2523:a7fa:383a",
+#endif
 
 
     struct TwoNodes* out = Allocator_calloc(alloc, sizeof(struct TwoNodes), 1);

--- a/test/Beacon_test.c
+++ b/test/Beacon_test.c
@@ -136,19 +136,17 @@ static void start(struct Allocator* alloc,
                   struct Random* rand,
                   RunTest* runTest)
 {
+    uint8_t address[16];
+    uint8_t publicKey[32];
+    uint8_t privateKeyA[32];
+    Key_gen(address, publicKey, privateKeyA, rand);
     struct TestFramework* a =
-        TestFramework_setUp("\xad\x7e\xa3\x26\xaa\x01\x94\x0a\x25\xbc\x9e\x01\x26\x22\xdb\x69"
-                            "\x4f\xd9\xb4\x17\x7c\xf3\xf8\x91\x16\xf3\xcf\xe8\x5c\x80\xe1\x4a",
-                            alloc, base, rand, logger);
-    //"publicKey": "kmzm4w0kj9bswd5qmx74nu7kusv5pj40vcsmp781j6xxgpd59z00.k",
-    //"ipv6": "fc41:94b5:0925:7ba9:3959:11ab:a006:367a",
+        TestFramework_setUp((char*) privateKeyA, alloc, base, rand, logger);
 
+    uint8_t privateKeyB[32];
+    Key_gen(address, publicKey, privateKeyB, rand);
     struct TestFramework* b =
-        TestFramework_setUp("\xd8\x54\x3e\x70\xb9\xae\x7c\x41\xbc\x18\xa4\x9a\x9c\xee\xca\x9c"
-                            "\xdc\x45\x01\x96\x6b\xbd\x7e\x76\xcf\x3a\x9f\xbc\x12\xed\x8b\xb4",
-                            alloc, base, rand, logger);
-    //"publicKey": "vz21tg07061s8v9mckrvgtfds7j2u5lst8cwl6nqhp81njrh5wg0.k",
-    //"ipv6": "fc1f:5b96:e1c5:625d:afde:2523:a7fa:383a",
+        TestFramework_setUp((char*) privateKeyB, alloc, base, rand, logger);
 
 
     struct TwoNodes* out = Allocator_calloc(alloc, sizeof(struct TwoNodes), 1);

--- a/tunnel/IpTunnel.c
+++ b/tunnel/IpTunnel.c
@@ -18,6 +18,7 @@
 #include "benc/Int.h"
 #include "benc/serialization/standard/BencMessageWriter.h"
 #include "benc/serialization/standard/BencMessageReader.h"
+#include "crypto/AddressCalc.h"
 #include "crypto/random/Random.h"
 #include "exception/Jmp.h"
 #include "interface/tuntap/TUNMessageType.h"
@@ -660,7 +661,10 @@ static bool isValidAddress6(uint8_t sourceAndDestIp6[32],
                             bool isFromTun,
                             struct IpTunnel_Connection* conn)
 {
-    if (sourceAndDestIp6[0] == 0xfc || sourceAndDestIp6[16] == 0xfc) { return false; }
+    if (AddressCalc_validAddress(sourceAndDestIp6)
+        || AddressCalc_validAddress(&sourceAndDestIp6[16])) {
+        return false;
+    }
     uint8_t* compareAddr = (isFromTun)
         ? ((conn->isOutgoing) ? sourceAndDestIp6 : &sourceAndDestIp6[16])
         : ((conn->isOutgoing) ? &sourceAndDestIp6[16] : sourceAndDestIp6);

--- a/tunnel/test/IpTunnel_test.c
+++ b/tunnel/test/IpTunnel_test.c
@@ -33,9 +33,6 @@
 #include "wire/Headers.h"
 #include "wire/Ethernet.h"
 
-#define PUBKEY "f3yqyp5qpmpfgvjyvtklff40510gxuuuh52vpyzvpbhh5glyfr60.k"
-#define IPV6 "fca9:f505:c650:8723:72a8:a524:530a:25c3"
-
 struct Context
 {
     struct Allocator* alloc;
@@ -373,12 +370,13 @@ int main()
     struct Log* logger = FileWriterLog_new(stdout, alloc);
     struct Random* rand = Random_new(alloc, logger, NULL);
     struct Context* ctx = Allocator_calloc(alloc, sizeof(struct Context), 1);
+    uint8_t privateKey[32];
     Identity_set(ctx);
     ctx->alloc = alloc;
     ctx->log = logger;
     ctx->rand = rand;
     ctx->base = eb;
-    Assert_true(!Key_parse(String_CONST(PUBKEY), ctx->pubKey, ctx->ipv6));
+    Assert_true(!Key_gen(ctx->ipv6, ctx->pubKey, privateKey, rand));
 
     testAddr(ctx, "192.168.1.1", 0, 32, NULL, 0, 0);
     testAddr(ctx, "192.168.1.1", 16, 24, NULL, 0, 0);


### PR DESCRIPTION
Add two environment variables to use a prefix other than fc00::/8.
For instance, `ADDRESS_PREFIX=0xfdd ADDRESS_PREFIX_BITS=12 ./do` will make cjdns use fdd0::/8.

All the magic is in `crypto/AddressCalc.c`.

Note that `Key_gen` takes a time exponential in the value of `ADDRESS_PREFIX_BITS`.