### PR TITLE
Update snode path periodicity

### DIFF
--- a/subnode/ReachabilityAnnouncer.c
+++ b/subnode/ReachabilityAnnouncer.c
@@ -475,6 +475,9 @@ static void onReplyTimeout(struct ReachabilityAnnouncer_pvt* rap, struct Address
     Allocator_free(mow->alloc);
     if (!Bits_memcmp(snodeAddr, &rap->snode, Address_SIZE)) {
         rap->snh->snodeIsReachable = false;
+        if (rap->snh->onSnodeUnreachable) {
+            rap->snh->onSnodeUnreachable(rap->snh, 0, 0);
+        }
     }
 }
 

--- a/subnode/SubnodePathfinder.c
+++ b/subnode/SubnodePathfinder.c
@@ -133,6 +133,9 @@ static Iface_DEFUN switchErr(struct Message* msg, struct SubnodePathfinder_pvt* 
         Log_debug(pf->log, "switch err from active snode [%s] type [%s][%d]",
             pathStr, Error_strerror(err), err);
         pf->pub.snh->snodeIsReachable = false;
+        if (pf->pub.snh->onSnodeUnreachable) {
+            pf->pub.snh->onSnodeUnreachable(pf->pub.snh, 0, 0);
+        }
     }
 
     return NULL;

--- a/subnode/SupernodeHunter.c
+++ b/subnode/SupernodeHunter.c
@@ -192,12 +192,12 @@ static void updateSnodePath2(Dict* msg, struct Address* src, struct MsgCore_Prom
     Log_debug(snp->log, "Supernode path updated with[%s]",
                         Address_toString(&al->elems[0], prom->alloc)->bytes);
 
+    snp->snodePathUpdated = true;
     if (!Bits_memcmp(&snp->pub.snodeAddr, &al->elems[0], Address_SIZE)) {
         return;
     }
     Bits_memcpy(&snp->pub.snodeAddr, &al->elems[0], Address_SIZE);
     Bits_memcpy(&snp->snodeCandidate, &al->elems[0], Address_SIZE);
-    snp->snodePathUpdated = true;
     if (snp->pub.onSnodeChange) {
         snp->pub.snodeIsReachable = (AddrSet_indexOf(snp->authorizedSnodes, src) != -1) ? 2 : 1;
         snp->pub.onSnodeChange(&snp->pub, q->sendTime, *snodeRecvTime);

--- a/subnode/SupernodeHunter.h
+++ b/subnode/SupernodeHunter.h
@@ -45,6 +45,7 @@ struct SupernodeHunter
     struct Address snodeAddr;
 
     SupernodeHunter_Callback onSnodeChange;
+    SupernodeHunter_Callback onSnodeUnreachable;
     void* userData;
 };
 


### PR DESCRIPTION
This commit want to fix this case, assume network topology is Snode->A->B->C, A got the snode path is splice(A->S), B got the snode path is splice(B->A->S), C got the snode path is splice(C->B->A->S). Now B crashed/restarted in whatever reason, it might receive the peer snode hunter GETSNODE reply from C first. Then B got the snode path is splice(B->C->B->A->S), when this case happened again and again, at last the snode path could not be spliced. It seems we need add snode path splice schedule job in SupernodeHunter module.