### PR TITLE
Fixes for building on GCC versions 7.x

### DIFF
--- a/benc/serialization/json/JsonBencSerializer.c
+++ b/benc/serialization/json/JsonBencSerializer.c
@@ -72,15 +72,15 @@ static int32_t serializeString(struct Writer* writer,
     Writer_write(writer, "\"", 1);
     size_t i;
     uint8_t chr;
-    char buffer[4];
+    char buffer[5];
     for (i = 0; i < string->len; i++) {
         chr = (uint8_t) string->bytes[i] & 0xFF;
         /* Nonprinting chars, \ and " are hex'd */
         if (chr < 126 && chr > 31 && chr != '\\' && chr != '"') {
-            snprintf(buffer, 4, "%c", chr);
+            snprintf(buffer, 5, "%c", chr);
             Writer_write(writer, buffer, 1);
         } else {
-            snprintf(buffer, 4, "\\x%.2X", chr);
+            snprintf(buffer, 5, "\\x%.2X", chr);
             Writer_write(writer, buffer, 4);
         }
     }

--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -1771,7 +1771,9 @@ struct NodeList* NodeStore_getPeers(uint64_t label,
         }
         switch (j) {
             default: Bits_memmove(out->nodes, &out->nodes[1], (j - 1) * sizeof(char*));
+                Gcc_FALLTHRU;
             case 1: out->nodes[j - 1] = next->child;
+                Gcc_FALLTHRU;
             case 0:;
         }
     }

--- a/subnode/GetPeersResponder.c
+++ b/subnode/GetPeersResponder.c
@@ -81,7 +81,9 @@ static void onGetPeers(Dict* msg,
         }
         switch (j) {
             default: Bits_memmove(ptrList, &ptrList[1], (j - 1) * sizeof(char*));
+                Gcc_FALLTHRU;
             case 1: ptrList[j - 1] = peer;
+                Gcc_FALLTHRU;
             case 0:;
         }
     }

--- a/util/Gcc.h
+++ b/util/Gcc.h
@@ -17,6 +17,18 @@
 
 #if !defined(__clang__) && \
     defined(__GNUC__) && \
+    (__GNUC__ > 6)
+
+#define Gcc_FALLTHRU \
+    __attribute__((fallthrough));
+
+#else
+#define Gcc_FALLTHRU
+
+#endif
+
+#if !defined(__clang__) && \
+    defined(__GNUC__) && \
     (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4))
 
 #define Gcc_PRINTF( format_idx, arg_idx ) \


### PR DESCRIPTION
Fixes for compilation on GCC 7.x rebased on crashey.  With the addition of conditional attributes allowing older GCC versions (including OpenBSD/NetBSD) to compile.  As before anything using clang hasn't presented warnings regarding fall-through so those don't seem to need any special handling at the moment.