### PR TITLE
fix NO_MARCH_FLAG cause -mnative never used bug

### DIFF
--- a/node_build/make.js
+++ b/node_build/make.js
@@ -92,7 +92,7 @@ Builder.configure({
     }
 
     if (!builder.config.crossCompiling) {
-        if (NO_MARCH_FLAG.indexOf(process.arch) < -1) {
+        if (NO_MARCH_FLAG.indexOf(process.arch) == -1) {
             builder.config.cflags.push('-march=native');
         }
     }
@@ -270,8 +270,8 @@ Builder.configure({
                 }
 
                 if (!builder.config.crossCompiling) {
-                    if (NO_MARCH_FLAG.indexOf(process.arch) < -1) {
-                        builder.config.cflags.push('-march=native');
+                    if (NO_MARCH_FLAG.indexOf(process.arch) == -1) {
+                        args.unshift('-march=native');
                     }
                 }
 


### PR DESCRIPTION
Old make script do not pass the -march=native args to the cnacl package. It will not detect the proper arch.

> Build NaCl
> Creating directories
> Getting system type
> System is [amd64]
> Using premade plan at [node_build/plans/amd64_plan.json]

After the commit, it shows:
> Build NaCl
> Creating directories
> Getting system type
> System is [amd64_AVX]
> Using premade plan at [node_build/plans/amd64_AVX_plan.json]

Also, the performance different bewteen enable/disable march=native is as below:
1499847457 INFO Benchmark.c:60 ---------------------------------------------------------------
1499847457 INFO Benchmark.c:62 Benchmark salsa20/poly1305 in 859ms. 1396973 kilobits per second
1499847457 INFO Benchmark.c:63 ---------------------------------------------------------------

vs

1499847611 INFO Benchmark.c:60 ---------------------------------------------------------------
1499847611 INFO Benchmark.c:62 Benchmark salsa20/poly1305 in 693ms. 1731601 kilobits per second
1499847611 INFO Benchmark.c:63 ---------------------------------------------------------------