### PR TITLE
Fix compile warning

### DIFF
--- a/node_build/dependencies/cnacl/crypto_scalarmult/curve25519/donna_c64/smult.c
+++ b/node_build/dependencies/cnacl/crypto_scalarmult/curve25519/donna_c64/smult.c
@@ -34,7 +34,7 @@ typedef limb felem[5];
 typedef unsigned uint128_t __attribute__((mode(TI)));
 
 #undef force_inline
-#define force_inline __attribute__((always_inline))
+#define force_inline inline __attribute__((always_inline))
 
 /* Sum two numbers: output += in */
 static void force_inline


### PR DESCRIPTION
Fix compile warning: 
crypto_scalarmult/curve25519/donna_c64/smult.c:149:1: warning: always_inline function might not be inlinable [-Wattributes]