### PR TITLE
Fix typo

### DIFF
--- a/node_build/dependencies/cnacl/node_build/plans/x86_AVX_plan.json
+++ b/node_build/dependencies/cnacl/node_build/plans/x86_AVX_plan.json
@@ -43,7 +43,7 @@
     [
       "crypto_onetimeauth",
       "poly1305",
-      "moon/avx/x86"
+      "moon/avx/32"
     ],
     [
       "crypto_stream",


### PR DESCRIPTION
Fix typo when using premade plan at [node_build/plans/x86_AVX_plan.json] with

`TARGET_ARCH="ia32" CFLAGS="-m32" LDFLAGS="-m32" ./do`