### PR TITLE
Stop RC traffic when peer told us him knew nothing about us yet

### DIFF
--- a/subnode/ReachabilityCollector.c
+++ b/subnode/ReachabilityCollector.c
@@ -154,7 +154,7 @@ static void onReply(Dict* msg, struct Address* src, struct MsgCore_Promise* prom
         return;
     }
     if (results->length < 8) {
-        // Peer gp response do not include my addr, means peer might not known us yet,
+        // Peer's gp response does not include my addr, meaning the peer might not know us yet.
         // should wait peer sendPing (see InterfaceControl.c).
         pi->pathToCheck = 1;
         return;

--- a/subnode/ReachabilityCollector.c
+++ b/subnode/ReachabilityCollector.c
@@ -153,7 +153,14 @@ static void onReply(Dict* msg, struct Address* src, struct MsgCore_Promise* prom
         mkNextRequest(rcp);
         return;
     }
-    pi->pathToCheck = (results->length < 8) ? 1 : path;
+    if (results->length < 8) {
+        // Peer gp response do not include my addr, means peer might not known us yet,
+        // should wait peer sendPing (see InterfaceControl.c).
+        pi->pathToCheck = 1;
+        return;
+    } else {
+        pi->pathToCheck = path;
+    }
     mkNextRequest(rcp);
 }
 


### PR DESCRIPTION
When subnode connected with an inbound, it will triggle the RC process, but subnode address need some time(serveral seconds or more) to appear in the inbound peers list. It will produce very large traffic in a very short time. 