### PR TITLE
Update peer path when got change event

### DIFF
--- a/subnode/ReachabilityCollector.c
+++ b/subnode/ReachabilityCollector.c
@@ -72,6 +72,7 @@ static void change0(struct ReachabilityCollector_pvt* rcp,
                 pi->pub.pathThemToUs = -1;
                 pi->pathToCheck = 1;
                 pi->pub.querying = true;
+                pi->pub.addr.path = nodeAddr->path;
             }
             if (rcp->pub.onChange) {
                 rcp->pub.onChange(&rcp->pub, nodeAddr->ip6.bytes, 0, 0, 0, 0xffff, 0xffff, 0xffff);


### PR DESCRIPTION
Update peer info path value once got chage event in RC, otherwise RC next request will never send gp request to the new path of neighbour.