### PR TITLE
Found peer re-handshake with us, triggle the peer gone event

### DIFF
--- a/net/InterfaceController.c
+++ b/net/InterfaceController.c
@@ -720,6 +720,10 @@ static Iface_DEFUN handleIncomingFromWire(struct Message* msg, struct Iface* add
         return NULL;
     }
     PeerLink_recv(msg, ep->peerLink);
+    if (ep->state == InterfaceController_PeerState_ESTABLISHED &&
+        CryptoAuth_getState(ep->caSession) != CryptoAuth_State_ESTABLISHED) {
+        sendPeer(0xffffffff, PFChan_Core_PEER_GONE, ep);
+    }
     return receivedPostCryptoAuth(msg, ep, ici->ic);
 }
 


### PR DESCRIPTION
Node A use node B as its inbound, when node B restart in whatever reason, the session on the node A will be re-handshake with node B. The PFChan_Core_PEER_GONE event should be triggled in this process, it will told A that B was gone and the A's RC to query the peer new pathToThem.