### PR TITLE
Reset log subscription entry memory after removed

### DIFF
--- a/admin/AdminLog.c
+++ b/admin/AdminLog.c
@@ -141,6 +141,7 @@ static void removeSubscription(struct AdminLog* log, struct Subscription* sub)
 {
     Allocator_free(sub->alloc);
     log->subscriptionCount--;
+    Bits_memset(sub, 0, sizeof(struct Subscription));
     if (log->subscriptionCount == 0 || sub == &log->subscriptions[log->subscriptionCount]) {
         return;
     }

--- a/admin/AdminLog.c
+++ b/admin/AdminLog.c
@@ -142,12 +142,6 @@ static void removeSubscription(struct AdminLog* log, struct Subscription* sub)
     Allocator_free(sub->alloc);
     log->subscriptionCount--;
     Bits_memset(sub, 0, sizeof(struct Subscription));
-    if (log->subscriptionCount == 0 || sub == &log->subscriptions[log->subscriptionCount]) {
-        return;
-    }
-    Bits_memcpy(sub,
-                &log->subscriptions[log->subscriptionCount],
-                sizeof(struct Subscription));
 }
 
 static void unpause(void* vAdminLog)


### PR DESCRIPTION
I have met the same problem as https://github.com/hyperboria/bugs/issues/123. Caused by old log subscription internal flag(internalFile) not cleaned when it removed.