### PR TITLE
Patch libuv build script for gcc 7

### DIFF
--- a/node_build/dependencies/libuv/gyp_uv.py
+++ b/node_build/dependencies/libuv/gyp_uv.py
@@ -34,6 +34,8 @@ def compiler_version():
   proc = subprocess.Popen(CC.split() + ['-dumpversion'], stdout=subprocess.PIPE)
   version = proc.communicate()[0].split('.')
   version = map(int, version[:2])
+  while len(version) < 2:
+    version.append(0)
   version = tuple(version)
   return (version, is_clang)
 


### PR DESCRIPTION
GCC 7 reports a version of `7` and not `7.0`.

Fixes https://github.com/hyperboria/bugs/issues/162