### PR TITLE
fix uv__getiovmax returning -1

### DIFF
--- a/node_build/dependencies/libuv/src/unix/stream.c
+++ b/node_build/dependencies/libuv/src/unix/stream.c
@@ -714,8 +714,18 @@ static int uv__getiovmax() {
   return IOV_MAX;
 #elif defined(_SC_IOV_MAX)
   static int iovmax = -1;
-  if (iovmax == -1)
+  if (iovmax == -1) {
+    errno = 0;
     iovmax = sysconf(_SC_IOV_MAX);
+    if (iovmax == -1) {
+      if (errno) {
+        iovmax = 1;
+      }
+      /*else {
+        iovmax = 1024;
+      }*/
+    }
+  }
   return iovmax;
 #else
   return 1024;
@@ -752,7 +762,7 @@ start:
   iovmax = uv__getiovmax();
 
   /* Limit iov count to avoid EINVALs from writev() */
-  if (iovcnt > iovmax)
+  if (iovcnt > iovmax && iovmax != -1)
     iovcnt = iovmax;
 
   /*

--- a/node_build/dependencies/libuv/src/unix/stream.c
+++ b/node_build/dependencies/libuv/src/unix/stream.c
@@ -729,7 +729,7 @@ static int uv__getiovmax() {
       if (errno) {
         iovmax = 1;
       }
-#ifdef __linux__
+#if defined(__linux__) && defined(UIO_IOVMAX)
       else {
         iovmax = UIO_IOVMAX;
       }

--- a/node_build/dependencies/libuv/src/unix/stream.c
+++ b/node_build/dependencies/libuv/src/unix/stream.c
@@ -713,8 +713,8 @@ static int uv__getiovmax() {
 #if defined(IOV_MAX)
   return IOV_MAX;
 #elif defined(_SC_IOV_MAX)
-  static int iovmax = -1;
-  if (iovmax == -1) {
+  static int iovmax = -2;
+  if (iovmax == -2) {
     errno = 0;
     iovmax = sysconf(_SC_IOV_MAX);
     if (iovmax == -1) {

--- a/node_build/dependencies/libuv/src/unix/stream.c
+++ b/node_build/dependencies/libuv/src/unix/stream.c
@@ -19,6 +19,10 @@
  * IN THE SOFTWARE.
  */
 
+#if !defined(_GNU_SOURCE) && defined(__linux__)
+#define _GNU_SOURCE
+#endif
+
 #include "uv.h"
 #include "internal.h"
 
@@ -34,6 +38,10 @@
 #include <sys/un.h>
 #include <unistd.h>
 #include <limits.h> /* IOV_MAX */
+
+#if !defined(IOV_MAX) && defined(__linux__)
+#include <linux/uio.h>
+#endif
 
 #if defined(__APPLE__)
 # include <sys/event.h>
@@ -721,9 +729,15 @@ static int uv__getiovmax() {
       if (errno) {
         iovmax = 1;
       }
+#ifdef __linux__
+      else {
+        iovmax = UIO_IOVMAX;
+      }
+#else
       /*else {
         iovmax = 1024;
       }*/
+#endif
     }
   }
   return iovmax;


### PR DESCRIPTION
If `uv__getiovmax` returns -1, the code thinks -1 is the actual upper bound, making `iovmax` negative, causing `writev` to fail, which then makes it impossible to successfully write to a pipe.

See https://github.com/libuv/libuv/pull/1539 why it still returns -1 if errno is 0.
