### PR TITLE
Fix compiler version test for gcc 7.2.0

### DIFF
--- a/node_build/dependencies/libuv/gyp_uv.py
+++ b/node_build/dependencies/libuv/gyp_uv.py
@@ -34,6 +34,7 @@ def compiler_version():
   proc = subprocess.Popen(CC.split() + ['-dumpversion'], stdout=subprocess.PIPE)
   version = proc.communicate()[0].split('.')
   version = map(int, version[:2])
+  version = (version + [0])[:2] # cc 7.2 returns 7 for dumpversion, force second component
   version = tuple(version)
   return (version, is_clang)
 


### PR DESCRIPTION
Make sure there are always at least two components for the cc dump version

```
$ cc --version
cc (Debian 7.2.0-4) 7.2.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ cc -dumpversion
7
```