### PR TITLE
Add support for configuring DSCP

### DIFF
--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -195,6 +195,10 @@ static void udpInterface(Dict* config, struct Context* ctx)
         if (bindStr) {
             Dict_putStringC(d, "bindAddress", bindStr, ctx->alloc);
         }
+        int64_t* dscp = Dict_getIntC(udp, "dscp");
+        if (dscp) {
+            Dict_putIntC(d, "dscp", *dscp, ctx->alloc);
+        }
         Dict* resp = NULL;
         rpcCall0(String_CONST("UDPInterface_new"), d, ctx, ctx->alloc, &resp, true);
         int ifNum = *(Dict_getIntC(resp, "interfaceNumber"));

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -162,6 +162,8 @@ static int genconf(struct Random* rand, bool eth)
            "            {\n"
            "                // Bind to this port.\n"
            "                \"bind\": \"0.0.0.0:%u\",\n", port);
+    printf("                // Set the DSCP value for Qos. Default is 0.\n"
+           "                // \"dscp\": 46,\n");
     printf("\n"
            "                // Nodes to connect to (IPv4 only).\n"
            "                \"connectTo\":\n"
@@ -181,6 +183,8 @@ static int genconf(struct Random* rand, bool eth)
            "            {\n"
            "                // Bind to this port.\n"
            "                \"bind\": \"[::]:%u\",\n", port);
+    printf("                // Set the DSCP value for Qos. Default is 0.\n"
+           "                // \"dscp\": 46,\n");
     printf("\n"
            "                // Nodes to connect to (IPv6 only).\n"
            "                \"connectTo\":\n"

--- a/util/events/UDPAddrIface.h
+++ b/util/events/UDPAddrIface.h
@@ -48,4 +48,6 @@ struct UDPAddrIface* UDPAddrIface_new(struct EventBase* base,
                                       struct Allocator* allocator,
                                       struct Except* exHandler,
                                       struct Log* logger);
+
+int UDPAddrIface_setDSCP(struct UDPAddrIface* iface, uint8_t dscp);
 #endif

--- a/util/events/libuv/UDPAddrIface.c
+++ b/util/events/libuv/UDPAddrIface.c
@@ -235,10 +235,10 @@ static int blockFreeInsideCallback(struct Allocator_OnFreeJob* job)
 
 int UDPAddrIface_setDSCP(struct UDPAddrIface* iface, uint8_t dscp)
 {
-    struct UDPAddrIface_pvt* context = Identity_check((struct UDPAddrIface_pvt*) iface);
     int res = 0;
     /* For win32 setsockopt is unable to mark the TOS field in IP header, do not support it now */
     #ifndef win32
+        struct UDPAddrIface_pvt* context = Identity_check((struct UDPAddrIface_pvt*) iface);
         /* 6-bit DSCP, 2-bit ENC(useless for UDP) */
         int tos = dscp << 2;
         if (Sockaddr_getFamily(context->pub.generic.addr) == Sockaddr_AF_INET) {

--- a/util/events/libuv/UDPAddrIface.c
+++ b/util/events/libuv/UDPAddrIface.c
@@ -233,6 +233,25 @@ static int blockFreeInsideCallback(struct Allocator_OnFreeJob* job)
     return Allocator_ONFREE_ASYNC;
 }
 
+int UDPAddrIface_setDSCP(struct UDPAddrIface* iface, uint8_t dscp)
+{
+    struct UDPAddrIface_pvt* context = Identity_check((struct UDPAddrIface_pvt*) iface);
+    int res = 0;
+    /* For win32 setsockopt is unable to mark the TOS field in IP header, do not support it now */
+    #ifndef win32
+        /* 6-bit DSCP, 2-bit ENC(useless for UDP) */
+        int tos = dscp << 2;
+        if (Sockaddr_getFamily(context->pub.generic.addr) == Sockaddr_AF_INET) {
+            res = setsockopt(context->uvHandle.io_watcher.fd, IPPROTO_IP, IP_TOS,
+                           &tos, sizeof(tos));
+        } else if (Sockaddr_getFamily(context->pub.generic.addr) == Sockaddr_AF_INET6) {
+            res = setsockopt(context->uvHandle.io_watcher.fd, IPPROTO_IPV6, IPV6_TCLASS,
+                           &tos, sizeof(tos));
+        }
+    #endif
+    return res;
+}
+
 struct UDPAddrIface* UDPAddrIface_new(struct EventBase* eventBase,
                                       struct Sockaddr* addr,
                                       struct Allocator* alloc,


### PR DESCRIPTION
Now we can mark the DSCP filed in both Ipv4/Ipv6 traffic. Current do not support win32 yet, See: https://support.microsoft.com/en-us/help/248611/setsockopt-is-unable-to-mark-the-internet-protocol-type-of-service-bit