### PR TITLE
Let Debian package build without setting extra variables

### DIFF
--- a/debian/do-wrapper
+++ b/debian/do-wrapper
@@ -11,8 +11,14 @@ if [[ "${DEB_BUILD_OPTIONS}" =~ nocheck ]]; then
     export NO_TEST=1
 fi
 
-export ADDRESS_PREFIX="${DEB_ADDRESS_PREFIX}"
-export ADDRESS_PREFIX_BITS="${DEB_ADDRESS_PREFIX_BITS}"
+# Pass through prefix overrides if they are set
+if [[ ${DEB_ADDRESS_PREFIX} && ${DEB_ADDRESS_PREFIX-x} ]]; then
+    export ADDRESS_PREFIX="${DEB_ADDRESS_PREFIX}"
+fi
+
+if [[ ${DEB_ADDRESS_PREFIX_BITS} && ${DEB_ADDRESS_PREFIX_BITS-x} ]]; then
+    export ADDRESS_PREFIX_BITS="${DEB_ADDRESS_PREFIX_BITS}"
+fi
 
 # Unset CFLAGS set by debhelper to fix a number of issues.
 # It usually contains something like this:


### PR DESCRIPTION
@ProgVal hooked up the prefix configuration to some `DEB_` variables, but when I just run `debuild` they aren't set, which results in the build system trying to use empty strings for the prefix bits and prefix length, and a predictable failure.

I've modified the Debian build wrapper to only set the variables the build uses if the `DEB_` variables are actually set. This lets `debuild` successfully build debs again.