### PR TITLE
Suspend compile warning and it might be failed if printf() is macro.

### DIFF
--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -253,15 +253,15 @@ static int genconf(struct Random* rand, bool eth)
            "            // The type of tunfd (only \"android\" for now)\n"
            "            // If \"android\" here, the tunDevice should be used as the pipe path\n"
            "            // to transfer the tun file description.\n"
-           "            // \"tunfd\" : \"android\"\n"
+           "            // \"tunfd\" : \"android\"\n");
 #ifndef __APPLE__
-           "\n"
+    printf("\n"
            "            // The name of a persistent TUN device to use.\n"
            "            // This for starting cjdroute as its own user.\n"
            "            // *MOST USERS DON'T NEED THIS*\n"
-           "            //\"tunDevice\": \"" DEFAULT_TUN_DEV "\"\n"
+           "            //\"tunDevice\": \"" DEFAULT_TUN_DEV "\"\n");
 #endif
-           "        },\n"
+    printf("        },\n"
            "\n"
            "        // System for tunneling IPv4 and ICANN IPv6 through cjdns.\n"
            "        // This is using the cjdns switch layer as a VPN carrier.\n"


### PR DESCRIPTION
clang compiler warnings:
client/cjdroute2.c:257:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
 ^
client/cjdroute2.c:263:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
 ^
2 warnings generated.