### PR TITLE
Fix unalign memory access, which may cause data fault on some archite…

### DIFF
--- a/crypto/AddressCalc.c
+++ b/crypto/AddressCalc.c
@@ -32,13 +32,13 @@
 
 bool AddressCalc_validAddress(const uint8_t address[16])
 {
-    uint64_t significant_bits = *((uint64_t*) address);
+    uint64_t significant_bits = *((uint64_t*)((uintptr_t) address & ~(uintptr_t)0xF));
     return (significant_bits & ADDRESS_PREFIX_MASK) == ADDRESS_PREFIX_U64;
 }
 
 void AddressCalc_makeValidAddress(uint8_t address[16])
 {
-    uint64_t* significant_bits = (uint64_t*) address;
+    uint64_t* significant_bits = (uint64_t*) ((uintptr_t) address & ~(uintptr_t)0xF);
     *significant_bits &= ~ADDRESS_PREFIX_MASK; // zero out the prefix
     *significant_bits |= ADDRESS_PREFIX_U64; // put the new prefix
 }


### PR DESCRIPTION
…ctures (old ARM or others)

crypto/AddressCalc.c:35:33: runtime error: load of misaligned address 0x62100003af44 for type 'uint64_t' (aka 'unsigned long'), which requires 8 byte alignment
0x62100003af44: note: pointer points here
  15 fa 98 8e ff 02 00 00  00 00 00 00 00 00 00 00  00 00 00 16 3a 00 05 02  00 00 01 00 8f 00 cf 64
              ^

@ProgVal  This issue is introduced by the https://github.com/cjdelisle/cjdns/commit/87202bea58d478e6bd5eeaec81124bac9fa11743