### PR TITLE
Fix unalign pointer conversion, which is unportable for some architectures

### DIFF
--- a/crypto/AddressCalc.c
+++ b/crypto/AddressCalc.c
@@ -32,15 +32,18 @@
 
 bool AddressCalc_validAddress(const uint8_t address[16])
 {
-    uint64_t significant_bits = *((uint64_t*) address);
+    uint64_t significant_bits;
+    Bits_memcpy (&significant_bits, address, sizeof(uint64_t));
     return (significant_bits & ADDRESS_PREFIX_MASK) == ADDRESS_PREFIX_U64;
 }
 
 void AddressCalc_makeValidAddress(uint8_t address[16])
 {
-    uint64_t* significant_bits = (uint64_t*) address;
-    *significant_bits &= ~ADDRESS_PREFIX_MASK; // zero out the prefix
-    *significant_bits |= ADDRESS_PREFIX_U64; // put the new prefix
+    uint64_t significant_bits;
+    Bits_memcpy (&significant_bits, address, sizeof(uint64_t));
+    significant_bits &= ~ADDRESS_PREFIX_MASK; // zero out the prefix
+    significant_bits |= ADDRESS_PREFIX_U64; // put the new prefix
+    Bits_memcpy (address, &significant_bits, sizeof(uint64_t));
 }
 
 bool AddressCalc_addressForPublicKey(uint8_t addressOut[16], const uint8_t key[32])


### PR DESCRIPTION
…tures(old ARM or others)

clang's error message:
```
crypto/AddressCalc.c:35:33: runtime error: load of misaligned address 0x61d00000264c for type 'uint64_t' (aka 'unsigned long'),
which requires 8 byte alignment
0x61d00000264c: note: pointer points here
  00 00 00 00 fc 41 94 b5  09 25 7b a9 39 59 11 ab  a0 06 36 7a 10 00 01 00  64 30 32 3a 65 69 69 30
              ^
```