### PR TITLE
Updated Ubuntu 16.04 installation

### DIFF
--- a/doc/install/ubuntu-16.04.md
+++ b/doc/install/ubuntu-16.04.md
@@ -1,6 +1,6 @@
 # Installing cjdns on Ubuntu 16.04
 
-This is a short guide how to setup an Ubuntu cjdns box.
+This is a short guide how to setup an Ubuntu cjdns box. Make sure you are running all this command as root either by "sudo su -" or log in as root.
 
 ## Install packages
 
@@ -13,8 +13,8 @@ This is a short guide how to setup an Ubuntu cjdns box.
 	cd cjdns
 	./do
 	ln -s /opt/cjdns/cjdroute /usr/bin
-	(umask 077 && ./cjdroute --genconf > /etc/cjdroute.conf)
 	cp contrib/systemd/cjdns.service /etc/systemd/system/
+	cp contrib/systemd/cjdns-resume.service /etc/systemd/system/
 	systemctl enable cjdns
 	systemctl start cjdns
 


### PR DESCRIPTION
Changed the installation step so that systemctl enable will not fail its due to cjdns-resume defined as Also in systemd unit file but cannot find the file. I was stumped by this error and took time to resolve.