### PR TITLE
Fix not working when random device is denied by selinux

### DIFF
--- a/crypto/random/seed/DevUrandomRandomSeed.c
+++ b/crypto/random/seed/DevUrandomRandomSeed.c
@@ -31,7 +31,7 @@ static int get(struct RandomSeed* randomSeed, uint64_t output[8])
     int fd = -1;
     int tries = 0;
     while ((fd = open("/dev/urandom", O_RDONLY, 0)) < 0) {
-        if (++tries > MAX_TRIES || errno == ENOENT) {
+        if (++tries > MAX_TRIES || errno != EINTR) {
             return -1;
         }
         sleep(1);

--- a/crypto/random/seed/ProcSysKernelRandomUuidRandomSeed.c
+++ b/crypto/random/seed/ProcSysKernelRandomUuidRandomSeed.c
@@ -33,7 +33,7 @@ static int getUUID(uint64_t output[2])
         int fd = -1;
         int tries = 0;
         while ((fd = open("/proc/sys/kernel/random/uuid", O_RDONLY, 0)) < 0) {
-            if (++tries > MAX_TRIES || errno == ENOENT) {
+            if (++tries > MAX_TRIES || errno != EINTR) {
                 return -1;
             }
             sleep(1);


### PR DESCRIPTION
On android oreo(8.0), "/proc/sys/kernel/random/uuid" is protected by selinux policy. cjdroute doesn't work because it use more than 10 seconds on the random device init stage.  
```
type=1400 audit(1483339661.227:16086): avc: denied { read } for pid=25393 comm="cjdroute" name="uuid" dev="proc" ino=154279 scontext=u:r:untrusted_app_25:s0:c512,c768 tcontext=u:object_r:proc:s0 tclass=file permissive=0 duplicate messages suppressed
type=1400 audit(1483339661.347:16087): avc: denied { read } for pid=25448 comm="cjdroute" name="uuid" dev="proc" ino=154279 scontext=u:r:untrusted_app_25:s0:c512,c768 tcontext=u:object_r:proc:s0 tclass=file permissive=0
```