### PR TITLE
fix build on raspberry pi by disabling -march=native for ARM

### DIFF
--- a/node_build/make.js
+++ b/node_build/make.js
@@ -29,7 +29,7 @@ var GCC = process.env['CC'];
 var CFLAGS = process.env['CFLAGS'];
 var LDFLAGS = process.env['LDFLAGS'];
 
-var NO_MARCH_FLAG = ['ppc', 'ppc64'];
+var NO_MARCH_FLAG = ['arm', 'ppc', 'ppc64'];
 
 if (GCC) {
     // Already specified.


### PR DESCRIPTION
`-march=native` does not work on Raspberry Pi 3 with old gcc compilers. This is [apparently a bug in gcc](https://www.raspberrypi.org/forums/viewtopic.php?f=33&t=174517)
and has been fixed in later versions (raspbian comes with gcc 4.9). Using `-mcpu=cortex-a53` instead of `-march=native` would also work, but because proper arch detection did not work before [this PR](https://github.com/cjdelisle/cjdns/pull/1075) just disabling it again for arm seems like an easy fix.


Before adding 'arm' to NO_MARCH_FLAG in node_build/make.js:
```
cjdns# Seccomp_NO=1 ./do
rebuildIfChanges changed, rebuilding
Initialize 180ms
{"isLLVM":false,"isClang":false,"isGCC":true,"version":"4.9.2"}
*** Error in `gcc': double free or corruption (top): 0x010cb1b8 ***
Configure 46ms
Compiler supports link time optimization
Scan for out of date files 9ms
*** Error in `gcc': double free or corruption (!prev): 0x01a7d038 ***
*** Error in `gcc': double free or corruption (top): 0x01318238 ***
*** Error in `gcc': double free or corruption (!prev): 0x01acf070 ***
*** Error in `gcc': double free or corruption (top): 0x0108f230 ***
*** Error in `gcc': double free or corruption (!prev): 0x010b2070 ***
*** Error in `gcc': double free or corruption (top): 0x01972230 ***
*** Error in `gcc': double free or corruption (!prev): 0x00c44070 ***
*** Error in `gcc': double free or corruption (top): 0x008a0230 ***
*** Error in `gcc': double free or corruption (!prev): 0x01a05070 ***
*** Error in `gcc': double free or corruption (top): 0x01314230 ***
*** Error in `gcc': double free or corruption (!prev): 0x01034070 ***
*** Error in `gcc': double free or corruption (top): 0x013b8230 ***
*** Error in `gcc': double free or corruption (!prev): 0x00e40070 ***
*** Error in `gcc': double free or corruption (top): 0x01781230 ***
*** Error in `gcc': double free or corruption (!prev): 0x00943038 ***
*** Error in `gcc': double free or corruption (top): 0x01f67238 ***
*** Error in `gcc': double free or corruption (top): 0x012771d0 ***
*** Error in `gcc': double free or corruption (top): 0x014a31f0 ***
*** Error in `gcc': double free or corruption (top): 0x00720208 ***
*** Error in `gcc': double free or corruption (top): 0x00ed51d0 ***
Building C object contrib/c/publictoip6.c complete
Linking C executable contrib/c/publictoip6.c
*** Error in `gcc': double free or corruption (top): 0x01393208 ***
Building C object contrib/c/privatetopublic.c complete
Linking C executable contrib/c/privatetopublic.c
Building C object contrib/c/sybilsim.c complete
Linking C executable contrib/c/sybilsim.c
*** Error in `gcc': double free or corruption (top): 0x00e99208 ***
Building C object client/cjdroute2.c complete
Linking C executable client/cjdroute2.c
Total build time: 932ms.
/root/code/projects/cjdns/node_build/builder.js:719
            if (err) { throw err; }
                       ^

Error: gcc -Wl,-z,relro,-z,now,-z,noexecstack,-pie,-flto,-O3 -o build_linux/contrib_c_privatetopublic_c build_linux/contrib_c_privatetopublic_c.o build_linux/dependencies/cnacl/jsbuild/libnacl.a,build_linux/dependencies/libuv/out/Release/libuv.a,-lpthread,-lrt

gcc: error: build_linux/contrib_c_privatetopublic_c.o: No such file or directory

    at error (/root/code/projects/cjdns/node_build/builder.js:53:15)
    at /root/code/projects/cjdns/node_build/builder.js:122:22
    at /root/code/projects/cjdns/node_build/builder.js:92:13
    at ChildProcess.<anonymous> (/root/code/projects/cjdns/tools/lib/Semaphore.js:7:30)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Socket.<anonymous> (internal/child_process.js:334:11)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
```

After:
```
cjdns# Seccomp_NO=1 ./do
rebuildIfChanges changed, rebuilding
Initialize 178ms
{"isLLVM":false,"isClang":false,"isGCC":true,"version":"4.9.2"}
Configure 45ms
Scan for out of date files 7ms
Compiler supports link time optimization
Building C object contrib/c/publictoip6.c complete
Building C object contrib/c/mkpasswd.c complete
Building C object contrib/c/privatetopublic.c complete
Building C object crypto/random/randombytes.c complete
Building C object contrib/c/makekeys.c complete
...
```