### PR TITLE
util/platform: fix "unknown" Sockaddr print

### DIFF
--- a/contrib/python/cjdnsadmin/adminTools.py
+++ b/contrib/python/cjdnsadmin/adminTools.py
@@ -114,7 +114,7 @@ def peerStats(cjdns,up=False,verbose=False,human_readable=False):
         i += 1
 
     if verbose:
-        STAT_FORMAT = '%s\tv%s\t%s\tin %s\tout %s\t%s\tdup %d los %d oor %d'
+        STAT_FORMAT = '%s\t%s\tv%s\t%s\tin %s\tout %s\t%s\tdup %d los %d oor %d'
 
         for peer in allPeers:
             ip = PublicToIp6_convert(peer['publicKey'])
@@ -125,7 +125,7 @@ def peerStats(cjdns,up=False,verbose=False,human_readable=False):
 				b_in  = sizeof_fmt(b_in)
 				b_out = sizeof_fmt(b_out)
             
-            p = STAT_FORMAT % (ip, peer['version'], peer['switchLabel'],
+            p = STAT_FORMAT % (peer['lladdr'], ip, peer['version'], peer['switchLabel'],
                                str(b_in), str(b_out), peer['state'],
                                peer['duplicates'], peer['lostPackets'],
                                peer['receivedOutOfRange'])

--- a/net/InterfaceController.c
+++ b/net/InterfaceController.c
@@ -940,6 +940,7 @@ int InterfaceController_getPeerStats(struct InterfaceController* ifController,
             struct Peer* peer = Identity_check((struct Peer*) ici->peerMap.values[i]);
             struct InterfaceController_PeerStats* s = &stats[xcount];
             xcount++;
+            s->lladdr = Sockaddr_clone(peer->lladdr, alloc);
             Bits_memcpy(&s->addr, &peer->addr, sizeof(struct Address));
             s->bytesOut = peer->bytesOut;
             s->bytesIn = peer->bytesIn;

--- a/net/InterfaceController.h
+++ b/net/InterfaceController.h
@@ -78,6 +78,7 @@ static inline char* InterfaceController_stateString(enum InterfaceController_Pee
 struct InterfaceController_PeerStats
 {
     struct Address addr;
+    struct Sockaddr* lladdr;
     int state;
     uint64_t timeOfLastMessage;
     uint64_t bytesOut;

--- a/net/InterfaceController_admin.c
+++ b/net/InterfaceController_admin.c
@@ -19,6 +19,7 @@
 #include "benc/Int.h"
 #include "crypto/AddressCalc.h"
 #include "crypto/Key.h"
+#include "interface/ETHInterface.h"
 #include "net/InterfaceController.h"
 #include "net/InterfaceController_admin.h"
 #include "util/AddrTools.h"
@@ -54,7 +55,15 @@ static void adminPeerStats(Dict* args, void* vcontext, String* txid, struct Allo
 
         Dict_putStringC(d, "addr", Address_toString(&stats[i].addr, alloc), alloc);
 
-        String* lladdrString = String_new(Sockaddr_print(stats[i].lladdr, alloc), alloc);
+        String* lladdrString;
+        if (ETHInterface_Sockaddr_SIZE == stats[i].lladdr->addrLen) {
+            struct ETHInterface_Sockaddr* eth = (struct ETHInterface_Sockaddr*) stats[i].lladdr;
+            uint8_t printedMac[18];
+            AddrTools_printMac(printedMac, eth->mac);
+            lladdrString = String_new(printedMac, alloc);
+        } else {
+            lladdrString = String_new(Sockaddr_print(stats[i].lladdr, alloc), alloc);
+        }
         Dict_putStringC(d, "lladdr", lladdrString, alloc);
 
         String* stateString = String_new(InterfaceController_stateString(stats[i].state), alloc);

--- a/net/InterfaceController_admin.c
+++ b/net/InterfaceController_admin.c
@@ -54,6 +54,9 @@ static void adminPeerStats(Dict* args, void* vcontext, String* txid, struct Allo
 
         Dict_putStringC(d, "addr", Address_toString(&stats[i].addr, alloc), alloc);
 
+        String* lladdrString = String_new(Sockaddr_print(stats[i].lladdr, alloc), alloc);
+        Dict_putStringC(d, "lladdr", lladdrString, alloc);
+
         String* stateString = String_new(InterfaceController_stateString(stats[i].state), alloc);
         Dict_putStringC(d, "state", stateString, alloc);
 

--- a/tools/peerStats
+++ b/tools/peerStats
@@ -23,7 +23,7 @@ Cjdns.connectAsAnon(function (cjdns) {
         cjdns.InterfaceController_peerStats(i, function (err, ret) {
             if (err) { throw err; }
             ret.peers.forEach(function (peer) {
-                p = peer['addr'] + ' ' + peer['state'] +
+                p = peer['lladdr'] + ' ' + peer['addr'] + ' ' + peer['state'] +
                     ' in ' + peer['recvKbps'] + 'kb/s' +
                     ' out ' + peer['sendKbps'] + 'kb/s';
 

--- a/util/platform/Sockaddr.c
+++ b/util/platform/Sockaddr.c
@@ -189,7 +189,8 @@ char* Sockaddr_print(struct Sockaddr* sockaddr, struct Allocator* alloc)
             break;
         default: {
             uint8_t buff[Sockaddr_MAXSIZE * 2 + 1] = {0};
-            Hex_encode(buff, sizeof(buff), (uint8_t*)&addr->ss, sockaddr->addrLen);
+            Hex_encode(buff, sizeof(buff), (uint8_t*)&addr->ss,
+                sockaddr->addrLen - Sockaddr_OVERHEAD);
             String* out = String_printf(alloc, "unknown (%s)", buff);
             return out->bytes;
         }


### PR DESCRIPTION
In the case that the Sockaddr address family is unknown, the `Sockaddr_print` function hex encodes the entire `addrLen` rather than `addrLen - Sockaddr_OVERHEAD`, thus going past the boundary of the actual allocated address storage. This fixes the issue.

This PR is based on #1156.