### PR TITLE
Add auto-peer support by using udp broadcast

### DIFF
--- a/admin/angel/Core.c
+++ b/admin/angel/Core.c
@@ -35,6 +35,7 @@
 #include "interface/tuntap/TUNInterface.h"
 #include "interface/tuntap/AndroidWrapper.h"
 #include "interface/UDPInterface_admin.h"
+#include "interface/UDPBcastInterface_admin.h"
 #ifdef HAS_ETH_INTERFACE
 #include "interface/ETHInterface_admin.h"
 #endif
@@ -282,6 +283,7 @@ void Core_init(struct Allocator* alloc,
     InterfaceController_admin_register(nc->ifController, admin, alloc);
     SwitchPinger_admin_register(nc->sp, admin, alloc);
     UDPInterface_admin_register(eventBase, alloc, logger, admin, nc->ifController, fakeNet);
+    UDPBcastInterface_admin_register(eventBase, alloc, logger, admin, nc->ifController);
 #ifdef HAS_ETH_INTERFACE
     ETHInterface_admin_register(eventBase, alloc, logger, admin, nc->ifController);
 #endif

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -149,29 +149,27 @@ This specifies the settings for the connection interfaces to your node. Right no
         */
         /*
         "UDPBcastInterface":
-        [
-            {
-                "bindAddress": "0.0.0.0:54200",
-                // Bind to this device (interface name or 'all', not MAC etc.)
-                "bindDevices": ["eth0"],
+        {
+            "bindAddress": "0.0.0.0:54200",
+            // Bind to this device (interface name or 'all', not MAC etc.)
+            "bindDevices": ["eth0"],
 
-                // Auto-connect to other cjdns nodes on the same network.
-                // Options:
-                //
-                // 0 -- Disabled.
-                //
-                // 1 -- Accept beacons, this will cause cjdns to accept incoming
-                //      beacon messages and try connecting to the sender.
-                //
-                // 2 -- Accept and send beacons, this will cause cjdns to broadcast
-                //      messages on the local network which contain a randomly
-                //      generated per-session password, other nodes which have this
-                //      set to 1 or 2 will hear the beacon messages and connect
-                //      automatically.
-                //
-                "beacon": 2,
-            }
-        ]
+            // Auto-connect to other cjdns nodes on the same network.
+            // Options:
+            //
+            // 0 -- Disabled.
+            //
+            // 1 -- Accept beacons, this will cause cjdns to accept incoming
+            //      beacon messages and try connecting to the sender.
+            //
+            // 2 -- Accept and send beacons, this will cause cjdns to broadcast
+            //      messages on the local network which contain a randomly
+            //      generated per-session password, other nodes which have this
+            //      set to 1 or 2 will hear the beacon messages and connect
+            //      automatically.
+            //
+            "beacon": 2,
+        }
         */
     },
 ````

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -147,6 +147,32 @@ This specifies the settings for the connection interfaces to your node. Right no
             }
         ]
         */
+        /*
+        "UDPBcastInterface":
+        [
+            {
+                "bindAddress": "0.0.0.0:54200",
+                // Bind to this device (interface name or 'all', not MAC etc.)
+                "bindDevices": ["eth0"],
+
+                // Auto-connect to other cjdns nodes on the same network.
+                // Options:
+                //
+                // 0 -- Disabled.
+                //
+                // 1 -- Accept beacons, this will cause cjdns to accept incoming
+                //      beacon messages and try connecting to the sender.
+                //
+                // 2 -- Accept and send beacons, this will cause cjdns to broadcast
+                //      messages on the local network which contain a randomly
+                //      generated per-session password, other nodes which have this
+                //      set to 1 or 2 will hear the beacon messages and connect
+                //      automatically.
+                //
+                "beacon": 2,
+            }
+        ]
+        */
     },
 ````
 
@@ -170,6 +196,11 @@ This specifies the settings for the connection interfaces to your node. Right no
     - `connectTo`: The connectTo for the ETHInterface functions almost exactly like it does for the the UDPInterface, except instead of an IP address and a port at the beginning, it is a MAC address.
     - `beacon`: This controls peer auto-discovery. Set to 0 to disable auto-peering, 1 to use broadcast auto-peering passwords contained in "beacon" messages from other nodes, and 2 to both broadcast and accept beacons.
     - In earlier versions of cjdns, it was necessary to uncomment the ETHInterface if you want to use it, however, now it is uncommented by default.
+
+- `UDPBcastInterface`:
+    - `bindAddress`: This tells cjdns which ipv4 address the UDPBcastInterface should bind to. This may be different depending on your setup. If you have already enable iptables rules please remember open the udp port for udp broadcast send/receive.
+    - `bindDevices`: This tells cjdns which device the UDPBcastInterface should bind to. This may be different depending on your setup.
+    - `beacon`: This controls peer auto-discovery. Set to 0 to disable auto-peering, 1 to use broadcast auto-peering passwords contained in "beacon" messages from other nodes, and 2 to both broadcast and accept beacons.
 
 Router
 ------

--- a/interface/UDPBcastInterface_admin.c
+++ b/interface/UDPBcastInterface_admin.c
@@ -1,0 +1,184 @@
+/* vim: set expandtab ts=4 sw=4: */
+/*
+ * You may redistribute this program and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "interface/UDPBcastInterface_admin.h"
+#include "benc/Int.h"
+#include "admin/Admin.h"
+#include "exception/Jmp.h"
+#include "memory/Allocator.h"
+#include "net/InterfaceController.h"
+#include "util/AddrTools.h"
+#include "util/Identity.h"
+#include "util/events/UDPBcastIface.h"
+
+struct Context
+{
+    struct EventBase* eventBase;
+    struct Allocator* alloc;
+    struct Log* logger;
+    struct Admin* admin;
+    struct InterfaceController* ic;
+    struct UDPBcastIface* udpIf;
+    int ifNum;
+    Identity
+};
+
+static void newInterface(Dict* args, void* vcontext, String* txid, struct Allocator* requestAlloc)
+{
+    struct Context* const ctx = Identity_check((struct Context*) vcontext);
+    List* const bindDevices = Dict_getListC(args, "bindDevices");
+    String* bindAddress = Dict_getStringC(args, "bindAddress");
+    struct Allocator* const alloc = Allocator_child(ctx->alloc);
+
+    if (ctx->ifNum > 0) {
+        Dict out = Dict_CONST(String_CONST("error"),
+                    String_OBJ(String_CONST("UDPBcastInterface already exist")), NULL
+        );
+        Admin_sendMessage(&out, txid, ctx->admin);
+        return;
+    }
+
+    struct Sockaddr_storage ss;
+    if (Sockaddr_parse(bindAddress->bytes, &ss)) {
+        Dict out = Dict_CONST(
+            String_CONST("error"), String_OBJ(String_CONST("Failed to parse address")), NULL
+        );
+        Admin_sendMessage(&out, txid, ctx->admin);
+        return;
+    }
+
+    if (Sockaddr_getFamily(&ss.addr) != Sockaddr_AF_INET ||
+        !Sockaddr_getPort(&ss.addr)) {
+        Dict out = Dict_CONST(String_CONST("error"),
+                String_OBJ(String_CONST("Invalid UDPBcastInterface bind address")), NULL
+        );
+        Admin_sendMessage(&out, txid, ctx->admin);
+        return;
+    }
+
+    struct Jmp jmp;
+    Jmp_try(jmp) {
+        ctx->udpIf = UDPBcastIface_new(
+            ctx->eventBase, &ss.addr, bindDevices, alloc, &jmp.handler, ctx->logger);
+    } Jmp_catch {
+        Dict* out = Dict_new(requestAlloc);
+        Dict_putStringCC(out, "error", jmp.message, requestAlloc);
+        Admin_sendMessage(out, txid, ctx->admin);
+        Allocator_free(alloc);
+        return;
+    }
+
+    String* ifname = String_printf(requestAlloc, "UDPBcast");
+
+    struct InterfaceController_Iface* ici = InterfaceController_newIface(ctx->ic, ifname, alloc);
+    Iface_plumb(&ici->addrIf, &ctx->udpIf->generic.iface);
+
+    Dict* out = Dict_new(requestAlloc);
+    Dict_putStringCC(out, "error", "none", requestAlloc);
+    Dict_putIntC(out, "interfaceNumber", ici->ifNum, requestAlloc);
+    ctx->ifNum = ici->ifNum;
+
+    Admin_sendMessage(out, txid, ctx->admin);
+}
+
+static void beacon(Dict* args, void* vcontext, String* txid, struct Allocator* requestAlloc)
+{
+    int64_t* stateP = Dict_getIntC(args, "state");
+    uint32_t state = (stateP) ? ((uint32_t) *stateP) : 0xffffffff;
+    struct Context* ctx = Identity_check((struct Context*) vcontext);
+
+    char* error = NULL;
+    int ret = InterfaceController_beaconState(ctx->ic, ctx->ifNum, state);
+    if (ret == InterfaceController_beaconState_NO_SUCH_IFACE) {
+        error = "invalid interfaceNumber";
+    } else if (ret == InterfaceController_beaconState_INVALID_STATE) {
+        error = "invalid state";
+    } else if (ret) {
+        error = "internal";
+    }
+
+    if (error) {
+        Dict* out = Dict_new(requestAlloc);
+        Dict_putStringCC(out, "error", error, requestAlloc);
+        Admin_sendMessage(out, txid, ctx->admin);
+        return;
+    }
+
+    char* stateStr = "disabled";
+    if (state == InterfaceController_beaconState_newState_ACCEPT) {
+        stateStr = "accepting";
+    } else if (state == InterfaceController_beaconState_newState_SEND) {
+        stateStr = "sending and accepting";
+    }
+
+    if (ctx->udpIf) {
+        UDPBcastIface_setBroadcast(ctx->udpIf, state ? true : false);
+    }
+
+    Dict out = Dict_CONST(
+        String_CONST("error"), String_OBJ(String_CONST("none")), Dict_CONST(
+        String_CONST("state"), Int_OBJ(state), Dict_CONST(
+        String_CONST("stateName"), String_OBJ(String_CONST(stateStr)), NULL
+    )));
+    Admin_sendMessage(&out, txid, ctx->admin);
+}
+
+static void listDevices(Dict* args, void* vcontext, String* txid, struct Allocator* requestAlloc)
+{
+    struct Context* ctx = Identity_check((struct Context*) vcontext);
+    List* devices = NULL;
+    struct Jmp jmp;
+    Jmp_try(jmp) {
+        devices = UDPBcastIface_listDevices(requestAlloc, &jmp.handler);
+    } Jmp_catch {
+        Dict* out = Dict_new(requestAlloc);
+        Dict_putStringCC(out, "error", jmp.message, requestAlloc);
+        Admin_sendMessage(out, txid, ctx->admin);
+        return;
+    }
+
+    Dict* out = Dict_new(requestAlloc);
+    Dict_putStringCC(out, "error", "none", requestAlloc);
+    Dict_putListC(out, "devices", devices, requestAlloc);
+    Admin_sendMessage(out, txid, ctx->admin);
+}
+
+void UDPBcastInterface_admin_register(struct EventBase* base,
+                                      struct Allocator* alloc,
+                                      struct Log* logger,
+                                      struct Admin* admin,
+                                      struct InterfaceController* ic)
+{
+    struct Context* ctx = Allocator_clone(alloc, (&(struct Context) {
+        .eventBase = base,
+        .alloc = alloc,
+        .logger = logger,
+        .admin = admin,
+        .ic = ic
+    }));
+    Identity_set(ctx);
+
+    Admin_registerFunction("UDPBcastInterface_new", newInterface, ctx, true,
+        ((struct Admin_FunctionArg[]) {
+            { .name = "bindAddress", .required = 1, .type = "String" },
+            { .name = "bindDevices", .required = 1, .type = "List" }
+        }), admin);
+
+    Admin_registerFunction("UDPBcastInterface_beacon", beacon, ctx, true,
+        ((struct Admin_FunctionArg[]) {
+            { .name = "state", .required = 0, .type = "Int" }
+        }), admin);
+
+    Admin_registerFunction("UDPBcastInterface_list", listDevices, ctx, true, NULL, admin);
+}

--- a/interface/UDPBcastInterface_admin.h
+++ b/interface/UDPBcastInterface_admin.h
@@ -1,0 +1,32 @@
+/* vim: set expandtab ts=4 sw=4: */
+/*
+ * You may redistribute this program and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef UDPBcastInterface_admin_H
+#define UDPBcastInterface_admin_H
+
+#include "admin/Admin.h"
+#include "memory/Allocator.h"
+#include "net/InterfaceController.h"
+#include "util/log/Log.h"
+#include "util/events/EventBase.h"
+#include "util/Linker.h"
+Linker_require("interface/UDPBcastInterface_admin.c");
+
+void UDPBcastInterface_admin_register(struct EventBase* base,
+                                      struct Allocator* alloc,
+                                      struct Log* logger,
+                                      struct Admin* admin,
+                                      struct InterfaceController* ic);
+
+#endif

--- a/net/InterfaceController.c
+++ b/net/InterfaceController.c
@@ -563,9 +563,11 @@ static Iface_DEFUN handleBeacon(struct Message* msg, struct InterfaceController_
         printedAddr = Address_toString(&addr, msg->alloc);
     }
 
-    if (!AddressCalc_validAddress(addr.ip6.bytes)
-        || !Bits_memcmp(ic->ca->publicKey, addr.key, 32)) {
+    if (!AddressCalc_validAddress(addr.ip6.bytes)) {
         Log_debug(ic->logger, "handleBeacon invalid key [%s]", printedAddr->bytes);
+        return NULL;
+    } else if (!Bits_memcmp(ic->ca->publicKey, addr.key, 32)) {
+        // receive beacon from self, drop silent
         return NULL;
     }
 

--- a/node_build/dependencies/libuv/src/win/util.c
+++ b/node_build/dependencies/libuv/src/win/util.c
@@ -758,11 +758,76 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
 }
 
 
+static int is_windows_version_or_greater(DWORD os_major,
+                                         DWORD os_minor,
+                                         WORD service_pack_major,
+                                         WORD service_pack_minor) {
+  OSVERSIONINFOEX osvi;
+  DWORDLONG condition_mask = 0;
+  int op = VER_GREATER_EQUAL;
+
+  /* Initialize the OSVERSIONINFOEX structure. */
+  ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
+  osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
+  osvi.dwMajorVersion = os_major;
+  osvi.dwMinorVersion = os_minor;
+  osvi.wServicePackMajor = service_pack_major;
+  osvi.wServicePackMinor = service_pack_minor;
+
+  /* Initialize the condition mask. */
+  VER_SET_CONDITION(condition_mask, VER_MAJORVERSION, op);
+  VER_SET_CONDITION(condition_mask, VER_MINORVERSION, op);
+  VER_SET_CONDITION(condition_mask, VER_SERVICEPACKMAJOR, op);
+  VER_SET_CONDITION(condition_mask, VER_SERVICEPACKMINOR, op);
+
+  /* Perform the test. */
+  return (int) VerifyVersionInfo(
+    &osvi, 
+    VER_MAJORVERSION | VER_MINORVERSION | 
+    VER_SERVICEPACKMAJOR | VER_SERVICEPACKMINOR,
+    condition_mask);
+}
+
+
+static int address_prefix_match(int family,
+                                struct sockaddr* address,
+                                struct sockaddr* prefix_address,
+                                int prefix_len) {
+  uint8_t* address_data;
+  uint8_t* prefix_address_data;
+  int i;
+
+  assert(address->sa_family == family);
+  assert(prefix_address->sa_family == family);
+
+  if (family == AF_INET6) {
+    address_data = (uint8_t*) &(((struct sockaddr_in6 *) address)->sin6_addr);
+    prefix_address_data =
+      (uint8_t*) &(((struct sockaddr_in6 *) prefix_address)->sin6_addr);
+  } else {
+    address_data = (uint8_t*) &(((struct sockaddr_in *) address)->sin_addr);
+    prefix_address_data =
+      (uint8_t*) &(((struct sockaddr_in *) prefix_address)->sin_addr);
+  }
+
+  for (i = 0; i < prefix_len >> 3; i++) {
+    if (address_data[i] != prefix_address_data[i])
+      return 0;
+  }
+
+  if (prefix_len % 8)
+    return prefix_address_data[i] ==
+      (address_data[i] & (0xff << (8 - prefix_len % 8)));
+
+  return 1;
+}
+
+
 int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
     int* count_ptr) {
   IP_ADAPTER_ADDRESSES* win_address_buf;
   ULONG win_address_buf_size;
-  IP_ADAPTER_ADDRESSES* win_address;
+  IP_ADAPTER_ADDRESSES* adapter;
 
   uv_interface_address_t* uv_address_buf;
   char* name_buf;
@@ -770,6 +835,23 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
   uv_interface_address_t* uv_address;
 
   int count;
+
+  int is_vista_or_greater;
+  ULONG flags;
+
+  is_vista_or_greater = is_windows_version_or_greater(6, 0, 0, 0);
+  if (is_vista_or_greater) {
+    flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
+      GAA_FLAG_SKIP_DNS_SERVER;
+  } else {
+    /* We need at least XP SP1. */
+    if (!is_windows_version_or_greater(5, 1, 1, 0))
+      return UV_ENOTSUP;
+
+    flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
+      GAA_FLAG_SKIP_DNS_SERVER | GAA_FLAG_INCLUDE_PREFIX;
+  }
+  
 
   /* Fetch the size of the adapters reported by windows, and then get the */
   /* list itself. */
@@ -783,7 +865,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
     /* ERROR_BUFFER_OVERFLOW, and the required buffer size will be stored in */
     /* win_address_buf_size. */
     r = GetAdaptersAddresses(AF_UNSPEC,
-                             GAA_FLAG_INCLUDE_PREFIX,
+                             flags,
                              NULL,
                              win_address_buf,
                              &win_address_buf_size);
@@ -842,25 +924,23 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
   count = 0;
   uv_address_buf_size = 0;
 
-  for (win_address = win_address_buf;
-       win_address != NULL;
-       win_address = win_address->Next) {
-    /* Use IP_ADAPTER_UNICAST_ADDRESS_XP to retain backwards compatibility */
-    /* with Windows XP */
-    IP_ADAPTER_UNICAST_ADDRESS_XP* unicast_address;
+  for (adapter = win_address_buf;
+       adapter != NULL;
+       adapter = adapter->Next) {
+    IP_ADAPTER_UNICAST_ADDRESS* unicast_address;
     int name_size;
 
     /* Interfaces that are not 'up' should not be reported. Also skip */
     /* interfaces that have no associated unicast address, as to avoid */
     /* allocating space for the name for this interface. */
-    if (win_address->OperStatus != IfOperStatusUp ||
-        win_address->FirstUnicastAddress == NULL)
+    if (adapter->OperStatus != IfOperStatusUp ||
+        adapter->FirstUnicastAddress == NULL)
       continue;
 
     /* Compute the size of the interface name. */
     name_size = WideCharToMultiByte(CP_UTF8,
                                     0,
-                                    win_address->FriendlyName,
+                                    adapter->FriendlyName,
                                     -1,
                                     NULL,
                                     0,
@@ -874,8 +954,8 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
 
     /* Count the number of addresses associated with this interface, and */
     /* compute the size. */
-    for (unicast_address = (IP_ADAPTER_UNICAST_ADDRESS_XP*)
-                           win_address->FirstUnicastAddress;
+    for (unicast_address = (IP_ADAPTER_UNICAST_ADDRESS*)
+                           adapter->FirstUnicastAddress;
          unicast_address != NULL;
          unicast_address = unicast_address->Next) {
       count++;
@@ -896,16 +976,15 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
   name_buf = (char*) (uv_address_buf + count);
 
   /* Fill out the output buffer. */
-  for (win_address = win_address_buf;
-       win_address != NULL;
-       win_address = win_address->Next) {
-    IP_ADAPTER_UNICAST_ADDRESS_XP* unicast_address;
-    IP_ADAPTER_PREFIX* prefix;
+  for (adapter = win_address_buf;
+       adapter != NULL;
+       adapter = adapter->Next) {
+    IP_ADAPTER_UNICAST_ADDRESS* unicast_address;
     int name_size;
     size_t max_name_size;
 
-    if (win_address->OperStatus != IfOperStatusUp ||
-        win_address->FirstUnicastAddress == NULL)
+    if (adapter->OperStatus != IfOperStatusUp ||
+        adapter->FirstUnicastAddress == NULL)
       continue;
 
     /* Convert the interface name to UTF8. */
@@ -914,7 +993,7 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
       max_name_size = INT_MAX;
     name_size = WideCharToMultiByte(CP_UTF8,
                                     0,
-                                    win_address->FriendlyName,
+                                    adapter->FriendlyName,
                                     -1,
                                     name_buf,
                                     (int) max_name_size,
@@ -926,47 +1005,77 @@ int uv_interface_addresses(uv_interface_address_t** addresses_ptr,
       return uv_translate_sys_error(GetLastError());
     }
 
-    prefix = win_address->FirstPrefix;
-
     /* Add an uv_interface_address_t element for every unicast address. */
-    /* Walk the prefix list in tandem with the address list. */
-    for (unicast_address = (IP_ADAPTER_UNICAST_ADDRESS_XP*)
-                           win_address->FirstUnicastAddress;
-         unicast_address != NULL && prefix != NULL;
-         unicast_address = unicast_address->Next, prefix = prefix->Next) {
+    for (unicast_address = (IP_ADAPTER_UNICAST_ADDRESS*)
+                           adapter->FirstUnicastAddress;
+         unicast_address != NULL;
+         unicast_address = unicast_address->Next) {
       struct sockaddr* sa;
       ULONG prefix_len;
 
       sa = unicast_address->Address.lpSockaddr;
-      prefix_len = prefix->PrefixLength;
+
+      /* XP has no OnLinkPrefixLength field. */
+      if (is_vista_or_greater) {
+        prefix_len = unicast_address->OnLinkPrefixLength;
+      } else {
+        /* Prior to Windows Vista the FirstPrefix pointed to the list with
+         * single prefix for each IP address assigned to the adapter.
+         * Order of FirstPrefix does not match order of FirstUnicastAddress,
+         * so we need to find corresponding prefix.
+         */
+        IP_ADAPTER_PREFIX* prefix;
+        prefix_len = 0;
+
+        for (prefix = adapter->FirstPrefix; prefix; prefix = prefix->Next) {
+          /* We want the longest matching prefix. */
+          if (prefix->Address.lpSockaddr->sa_family != sa->sa_family ||
+              prefix->PrefixLength <= prefix_len)
+            continue;
+
+          if (address_prefix_match(sa->sa_family, sa, 
+              prefix->Address.lpSockaddr, prefix->PrefixLength)) {
+            prefix_len = prefix->PrefixLength;
+          }
+        }
+
+        /* If there is no matching prefix information, return a single-host
+         * subnet mask (e.g. 255.255.255.255 for IPv4). 
+         */
+        if (!prefix_len)
+          prefix_len = (sa->sa_family == AF_INET6) ? 128 : 32;
+      }
 
       memset(uv_address, 0, sizeof *uv_address);
 
       uv_address->name = name_buf;
 
-      if (win_address->PhysicalAddressLength == sizeof(uv_address->phys_addr)) {
+      if (adapter->PhysicalAddressLength == sizeof(uv_address->phys_addr)) {
         memcpy(uv_address->phys_addr,
-               win_address->PhysicalAddress,
+               adapter->PhysicalAddress,
                sizeof(uv_address->phys_addr));
       }
 
       uv_address->is_internal =
-          (win_address->IfType == IF_TYPE_SOFTWARE_LOOPBACK);
+          (adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK);
 
       if (sa->sa_family == AF_INET6) {
         uv_address->address.address6 = *((struct sockaddr_in6 *) sa);
 
         uv_address->netmask.netmask6.sin6_family = AF_INET6;
         memset(uv_address->netmask.netmask6.sin6_addr.s6_addr, 0xff, prefix_len >> 3);
-        uv_address->netmask.netmask6.sin6_addr.s6_addr[prefix_len >> 3] =
-            0xff << (8 - prefix_len % 8);
+        /* This check ensures that we don't write past the size of the data. */
+        if (prefix_len % 8) {
+          uv_address->netmask.netmask6.sin6_addr.s6_addr[prefix_len >> 3] =
+              0xff << (8 - prefix_len % 8);
+        }
 
       } else {
         uv_address->address.address4 = *((struct sockaddr_in *) sa);
 
         uv_address->netmask.netmask4.sin_family = AF_INET;
-        uv_address->netmask.netmask4.sin_addr.s_addr =
-            htonl(0xffffffff << (32 - prefix_len));
+        uv_address->netmask.netmask4.sin_addr.s_addr = (prefix_len > 0) ?
+            htonl(0xffffffff << (32 - prefix_len)) : 0;
       }
 
       uv_address++;

--- a/util/events/UDPBcastIface.h
+++ b/util/events/UDPBcastIface.h
@@ -1,0 +1,83 @@
+/* vim: set expandtab ts=4 sw=4: */
+/*
+ * You may redistribute this program and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef UDPBcastIface_H
+#define UDPBcastIface_H
+
+#include "benc/List.h"
+#include "exception/Except.h"
+#include "interface/Iface.h"
+#include "interface/addressable/AddrIface.h"
+#include "memory/Allocator.h"
+#include "util/events/EventBase.h"
+#include "util/Gcc.h"
+#include "util/log/Log.h"
+#include "util/Linker.h"
+
+#include <stdbool.h>
+Linker_require("util/events/libuv/UDPBcastIface.c");
+
+#define UDPBcastIface_CURRENT_VERSION 0
+#define UDPBcastIface_PADDING_AMOUNT 512
+#define UDPBcastIface_BUFFER_CAP 3496
+
+/** Maximum number of bytes to hold in queue before dropping packets. */
+#define UDPBcastIface_MAX_QUEUE 16384
+
+#define UDPBcastIface_CURRENT_VERSION 0
+Gcc_PACKED
+struct UDPBcastIface_Header
+{
+    /** UDPBcastIface_CURRENT_VERSION, no communication is possible with different versions. */
+    uint8_t version;
+
+    /** padding and for future use. */
+    uint8_t zero;
+
+    /** Length of the content (excluding header) */
+    uint16_t length_be;
+
+    uint8_t bcast;
+    uint8_t reversed;
+
+    /** Pad to align boundry, also magic. */
+    uint16_t fb00_be;
+};
+#define UDPBcastIface_Header_SIZE 8
+Assert_compileTime(sizeof(struct UDPBcastIface_Header) == UDPBcastIface_Header_SIZE);
+
+struct UDPBcastIface
+{
+    struct AddrIface generic;
+};
+
+/**
+ * @param base the event loop context.
+ * @param bindAddr the address/port to bind to.
+ * @param allocator the memory allocator for this message.
+ * @param exHandler the handler to deal with whatever exception arises.
+ * @param logger
+ * @return a new UDPBcastInterfaceBase.
+ */
+struct UDPBcastIface* UDPBcastIface_new(struct EventBase* base,
+                                        struct Sockaddr* bindAddr,
+                                        const List* bindDevices,
+                                        struct Allocator* allocator,
+                                        struct Except* exHandler,
+                                        struct Log* logger);
+
+int UDPBcastIface_setBroadcast(struct UDPBcastIface* iface, bool enable);
+List* UDPBcastIface_listDevices(struct Allocator* alloc, struct Except* eh);
+
+#endif

--- a/util/events/UDPBcastIface.h
+++ b/util/events/UDPBcastIface.h
@@ -52,7 +52,7 @@ struct UDPBcastIface_Header
     uint8_t reversed;
 
     /** Pad to align boundry, also magic. */
-    uint16_t fb00_be;
+    uint16_t magic_be;
 };
 #define UDPBcastIface_Header_SIZE 8
 Assert_compileTime(sizeof(struct UDPBcastIface_Header) == UDPBcastIface_Header_SIZE);

--- a/util/events/libuv/UDPBcastIface.c
+++ b/util/events/libuv/UDPBcastIface.c
@@ -141,7 +141,7 @@ static Iface_DEFUN incomingFromIface(struct Message* m, struct Iface* iface)
         .length_be = Endian_hostToBigEndian16(m->length + UDPBcastIface_Header_SIZE),
         .bcast = 0,
         .reversed = 0,
-        .fb00_be= Endian_hostToBigEndian16(0xfb00),
+        .magic_be= Endian_hostToBigEndian16(0xfc00),
     };
 
     if (sa->flags & Sockaddr_flags_BCAST) {
@@ -246,7 +246,7 @@ static void incoming(uv_udp_t* handle,
                 m->length = reportedLength;
             }
 
-            if (hdr.fb00_be != Endian_hostToBigEndian16(0xfb00)) {
+            if (hdr.magic_be != Endian_hostToBigEndian16(0xfc00)) {
                 Log_debug(context->logger, "DROP bad magic");
                 break;
             }

--- a/util/events/libuv/UDPBcastIface.c
+++ b/util/events/libuv/UDPBcastIface.c
@@ -253,7 +253,7 @@ static void incoming(uv_udp_t* handle,
 
             if (!context->bcast) {
                 Log_debug(context->logger, "Drop packet with bcast disabled");
-                return;
+                break;
             }
 
             struct Sockaddr laddr;

--- a/util/events/libuv/UDPBcastIface.c
+++ b/util/events/libuv/UDPBcastIface.c
@@ -1,0 +1,447 @@
+/* vim: set expandtab ts=4 sw=4: */
+/*
+ * You may redistribute this program and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "util/events/libuv/UvWrapper.h"
+#include "exception/Except.h"
+#include "interface/Iface.h"
+#include "util/events/UDPBcastIface.h"
+#include "memory/Allocator.h"
+#include "util/events/libuv/EventBase_pvt.h"
+#include "util/platform/Sockaddr.h"
+#include "util/Assert.h"
+#include "util/Identity.h"
+#include "wire/Message.h"
+#include "wire/Error.h"
+#include "util/Hex.h"
+#include "benc/String.h"
+
+struct UDPBcastIface_pvt
+{
+    struct UDPBcastIface pub;
+
+    struct Allocator* allocator;
+
+    struct Log* logger;
+
+    /** Job to close the handle when the allocator is freed */
+    struct Allocator_OnFreeJob* closeHandleOnFree;
+
+    /** Job which blocks the freeing until the callback completes */
+    struct Allocator_OnFreeJob* blockFreeInsideCallback;
+
+    uv_udp_t uvHandle;
+    int queueLen;
+    bool bcast;
+    List* devices;
+
+    /** true if we are inside of the callback, used by blockFreeInsideCallback */
+    int inCallback;
+
+    Identity
+};
+
+struct UDPBcastIface_WriteRequest_pvt {
+    uv_udp_send_t uvReq;
+    int32_t length;
+    struct UDPBcastIface_pvt* udp;
+    struct Message* msg;
+    struct Allocator* alloc;
+    Identity
+};
+
+static struct UDPBcastIface_pvt* ifaceForHandle(uv_udp_t* handle)
+{
+    char* hp = ((char*)handle) - offsetof(struct UDPBcastIface_pvt, uvHandle);
+    return Identity_check((struct UDPBcastIface_pvt*) hp);
+}
+
+static void sendComplete(uv_udp_send_t* uvReq, int error)
+{
+    struct UDPBcastIface_WriteRequest_pvt* req =
+        Identity_check((struct UDPBcastIface_WriteRequest_pvt*) uvReq);
+    if (error) {
+        Log_debug(req->udp->logger, "DROP Failed to write to UDPBcastIface [%s]",
+                  uv_strerror(error) );
+    }
+    Assert_true(req->msg->length == req->length);
+    req->udp->queueLen -= req->msg->length;
+    Assert_true(req->udp->queueLen >= 0);
+    Allocator_free(req->alloc);
+}
+
+static void sendPacket(struct Message* m, struct sockaddr* addr, struct Iface* iface)
+{
+    struct Message* msg;
+    struct UDPBcastIface_pvt* context = Identity_check((struct UDPBcastIface_pvt*) iface);
+
+    // This allocator will hold the message allocator in existance after it is freed.
+    struct Allocator* reqAlloc = Allocator_child(context->allocator);
+    msg = Message_clone(m, reqAlloc);
+
+    struct UDPBcastIface_WriteRequest_pvt* req =
+        Allocator_clone(reqAlloc, (&(struct UDPBcastIface_WriteRequest_pvt) {
+            .udp = context,
+            .msg = msg,
+            .alloc = reqAlloc
+        }));
+    Identity_set(req);
+
+    req->length = msg->length;
+
+    uv_buf_t buffers[] = {
+        { .base = (char*)msg->bytes, .len = msg->length }
+    };
+
+    int ret = uv_udp_send(&req->uvReq, &context->uvHandle, buffers, 1,
+                          addr, (uv_udp_send_cb)&sendComplete);
+
+    if (ret) {
+        Log_info(context->logger, "DROP Failed writing to UDPBcastIface [%s]",
+                 uv_strerror(ret));
+        Allocator_free(req->alloc);
+        return;
+    }
+    context->queueLen += msg->length;
+}
+
+static Iface_DEFUN incomingFromIface(struct Message* m, struct Iface* iface)
+{
+    struct UDPBcastIface_pvt* context = Identity_check((struct UDPBcastIface_pvt*) iface);
+
+    Assert_true(m->length >= Sockaddr_OVERHEAD);
+
+    if ((((struct Sockaddr*)m->bytes)->flags & Sockaddr_flags_BCAST) && !context->bcast) {
+        Log_debug(context->logger, "Attempted bcast with bcast disabled");
+        return NULL;
+    }
+
+    if (context->queueLen > UDPBcastIface_MAX_QUEUE) {
+        Log_warn(context->logger, "DROP Maximum queue length reached");
+        return NULL;
+    }
+
+    struct Sockaddr* sa = (struct Sockaddr*) m->bytes;
+    struct Sockaddr_storage ss;
+    Message_pop(m, &ss, sa->addrLen, NULL);
+
+    struct UDPBcastIface_Header hdr = {
+        .version = UDPBcastIface_CURRENT_VERSION,
+        .zero = 0,
+        .length_be = Endian_hostToBigEndian16(m->length + UDPBcastIface_Header_SIZE),
+        .bcast = 0,
+        .reversed = 0,
+        .fb00_be= Endian_hostToBigEndian16(0xfb00),
+    };
+
+    if (sa->flags & Sockaddr_flags_BCAST) {
+        // We will send the message to bcast addr of all selected interfaces
+        uv_interface_address_t* interfaces;
+        int i, j, count;
+        int res = uv_interface_addresses(&interfaces, &count);
+        if (res) {
+            Log_warn(context->logger, "DROP message for none interface available");
+            return NULL;
+        }
+
+        struct Allocator* tmpAlloc = Allocator_child(context->allocator);
+        int32_t bcastCount = List_size(context->devices);
+
+        hdr.bcast = 1;
+        Message_push(m, &hdr, UDPBcastIface_Header_SIZE, NULL);
+
+        for (i = 0; i < count; i++) {
+            if (interfaces[i].is_internal) { continue; }
+            if (interfaces[i].address.address4.sin_family != AF_INET) { continue; }
+
+            for (j = 0; j < bcastCount; j++) {
+                String* device = List_getString(context->devices, j);
+                if (!CString_strcmp(interfaces[i].name, device->bytes)) { break; }
+            }
+
+            if (j == bcastCount) { continue; }
+
+            // calculate the broadcast address
+            struct sockaddr_in bcast4 = {
+                .sin_family = AF_INET,
+                .sin_port = htons(Sockaddr_getPort(context->pub.generic.addr)),
+                .sin_addr = { .s_addr =
+                    (interfaces[i].address.address4.sin_addr.s_addr &
+                     interfaces[i].netmask.netmask4.sin_addr.s_addr) |
+                        ~interfaces[i].netmask.netmask4.sin_addr.s_addr}
+            };
+
+            sendPacket(m, (struct sockaddr*)&bcast4, iface);
+        }
+        uv_free_interface_addresses(interfaces, count);
+        Allocator_free(tmpAlloc);
+    } else {
+        Message_push(m, &hdr, UDPBcastIface_Header_SIZE, NULL);
+        sendPacket(m, (struct sockaddr*)ss.nativeAddr, iface);
+    }
+
+    return NULL;
+}
+
+#if UDPBcastIface_PADDING_AMOUNT < 8
+    #error
+#endif
+#define ALLOC(buff) (((struct Allocator**) &(buff[-(8 + (((uintptr_t)buff) % 8))]))[0])
+
+static void incoming(uv_udp_t* handle,
+                     ssize_t nread,
+                     const uv_buf_t* buf,
+                     const struct sockaddr* addr,
+                     unsigned flags)
+{
+    struct UDPBcastIface_pvt* context = ifaceForHandle(handle);
+
+    context->inCallback = 1;
+
+    // Grab out the allocator which was placed there by allocate()
+    struct Allocator* alloc = buf->base ? ALLOC(buf->base) : NULL;
+
+    // if nread < 0, we used to log uv_last_error, which doesn't exist anymore.
+    if (nread == 0) {
+        // Happens constantly
+        //Log_debug(context->logger, "0 length read");
+
+    } else if (nread < UDPBcastIface_Header_SIZE) {
+        Log_debug(context->logger, "Failed to receive udp bcast frame");
+    } else {
+        do {
+            struct Message* m = Allocator_calloc(alloc, sizeof(struct Message), 1);
+            m->length = nread;
+            m->padding = UDPBcastIface_PADDING_AMOUNT + context->pub.generic.addr->addrLen;
+            m->capacity = buf->len;
+            m->bytes = (uint8_t*)buf->base;
+            m->alloc = alloc;
+
+
+            struct UDPBcastIface_Header hdr;
+            Message_pop(m, &hdr, UDPBcastIface_Header_SIZE, NULL);
+
+            if (hdr.version != UDPBcastIface_CURRENT_VERSION) {
+                Log_debug(context->logger, "DROP unknown version");
+                break;
+            }
+
+            uint16_t reportedLength = Endian_bigEndianToHost16(hdr.length_be);
+            reportedLength -= UDPBcastIface_Header_SIZE;
+            if (m->length != reportedLength) {
+                if (m->length < reportedLength) {
+                    Log_debug(context->logger, "DROP size field is larger than frame");
+                    break;
+                }
+                m->length = reportedLength;
+            }
+
+            if (hdr.fb00_be != Endian_hostToBigEndian16(0xfb00)) {
+                Log_debug(context->logger, "DROP bad magic");
+                break;
+            }
+
+            if (!context->bcast) {
+                Log_debug(context->logger, "Drop packet with bcast disabled");
+                return;
+            }
+
+            struct Sockaddr laddr;
+            Bits_memcpy(&laddr, context->pub.generic.addr, Sockaddr_OVERHEAD);
+            if (hdr.bcast) {
+                laddr.flags |= Sockaddr_flags_BCAST;
+            }
+
+            Message_push(m, addr, context->pub.generic.addr->addrLen - Sockaddr_OVERHEAD, NULL);
+
+            // make sure the sockaddr doesn't have crap in it which will
+            // prevent it from being used as a lookup key
+            Sockaddr_normalizeNative((struct sockaddr*) m->bytes);
+
+            Message_push(m, &laddr, Sockaddr_OVERHEAD, NULL);
+
+            Iface_send(&context->pub.generic.iface, m);
+        } while (0);
+    }
+
+    if (alloc) {
+        Allocator_free(alloc);
+    }
+
+    context->inCallback = 0;
+    if (context->blockFreeInsideCallback) {
+        Allocator_onFreeComplete((struct Allocator_OnFreeJob*) context->blockFreeInsideCallback);
+    }
+}
+
+static void allocate(uv_handle_t* handle, size_t size, uv_buf_t* buf)
+{
+    struct UDPBcastIface_pvt* context = ifaceForHandle((uv_udp_t*)handle);
+
+    size = UDPBcastIface_BUFFER_CAP;
+    size_t fullSize = size + UDPBcastIface_PADDING_AMOUNT + context->pub.generic.addr->addrLen;
+
+    struct Allocator* child = Allocator_child(context->allocator);
+    char* buff = Allocator_malloc(child, fullSize);
+    buff += UDPBcastIface_PADDING_AMOUNT + context->pub.generic.addr->addrLen;
+
+    ALLOC(buff) = child;
+
+    buf->base = buff;
+    buf->len = size;
+}
+
+static void onClosed(uv_handle_t* wasClosed)
+{
+    struct UDPBcastIface_pvt* context =
+        Identity_check((struct UDPBcastIface_pvt*) wasClosed->data);
+    Allocator_onFreeComplete((struct Allocator_OnFreeJob*) context->closeHandleOnFree);
+}
+
+static int closeHandleOnFree(struct Allocator_OnFreeJob* job)
+{
+    struct UDPBcastIface_pvt* context =
+        Identity_check((struct UDPBcastIface_pvt*) job->userData);
+    context->closeHandleOnFree = job;
+    uv_close((uv_handle_t*)&context->uvHandle, onClosed);
+    return Allocator_ONFREE_ASYNC;
+}
+
+static int blockFreeInsideCallback(struct Allocator_OnFreeJob* job)
+{
+    struct UDPBcastIface_pvt* context =
+        Identity_check((struct UDPBcastIface_pvt*) job->userData);
+    if (!context->inCallback) {
+        return 0;
+    }
+    context->blockFreeInsideCallback = job;
+    return Allocator_ONFREE_ASYNC;
+}
+
+List* UDPBcastIface_listDevices(struct Allocator* alloc, struct Except* eh)
+{
+    List* out = List_new(alloc);
+    uv_interface_address_t* interfaces;
+    int i, count;
+    int res = uv_interface_addresses(&interfaces, &count);
+    if (res) {
+        return out;
+    }
+
+    for (i = 0; i < count; i++) {
+        if (interfaces[i].is_internal) { continue; }
+        if (interfaces[i].address.address4.sin_family != AF_INET) { continue; }
+
+        List_addString(out, String_new(interfaces[i].name, alloc), alloc);
+    }
+    uv_free_interface_addresses(interfaces, count);
+    return out;
+}
+
+
+int UDPBcastIface_setBroadcast(struct UDPBcastIface* iface, bool enable)
+{
+    struct UDPBcastIface_pvt* context = Identity_check((struct UDPBcastIface_pvt*) iface);
+    int res = uv_udp_set_broadcast(&context->uvHandle, enable ? 1 : 0);
+    if (!res) {
+        context->bcast = enable;
+    }
+    return res;
+}
+
+struct UDPBcastIface* UDPBcastIface_new(struct EventBase* eventBase,
+                                        struct Sockaddr* addr,
+                                        const List* devices,
+                                        struct Allocator* alloc,
+                                        struct Except* exHandler,
+                                        struct Log* logger)
+{
+    struct EventBase_pvt* base = EventBase_privatize(eventBase);
+
+    struct UDPBcastIface_pvt* context =
+        Allocator_clone(alloc, (&(struct UDPBcastIface_pvt) {
+            .logger = logger,
+            .bcast = true,
+            .allocator = alloc
+        }));
+    context->pub.generic.alloc = alloc;
+    context->pub.generic.iface.send = incomingFromIface;
+    Identity_set(context);
+
+    if (!addr) {
+        Except_throw(exHandler, "Must assign the bcast address.");
+    }
+    Log_debug(logger, "Binding to address [%s]", Sockaddr_print(addr, alloc));
+
+    if (!Sockaddr_getPort(addr)) {
+        Except_throw(exHandler, "Must assign the bcast port.");
+    }
+
+    if (Sockaddr_getFamily(addr) != Sockaddr_AF_INET) {
+        Except_throw(exHandler, "UDP broadcast only supported by ipv4.");
+    }
+
+    uv_udp_init(base->loop, &context->uvHandle);
+    context->uvHandle.data = context;
+
+    void* native = Sockaddr_asNative(addr);
+    int ret = uv_udp_bind(&context->uvHandle, (const struct sockaddr*)native, 0);
+
+    if (ret) {
+        Except_throw(exHandler, "call to uv_udp_bind() failed [%s]",
+                     uv_strerror(ret));
+    }
+
+    ret = uv_udp_set_broadcast(&context->uvHandle, 1);
+
+    if (ret) {
+        Except_throw(exHandler, "call to uv_udp_set_broadcast() failed [%s]",
+                     uv_strerror(ret));
+    }
+
+    ret = uv_udp_recv_start(&context->uvHandle, allocate, incoming);
+    if (ret) {
+        const char* err = uv_strerror(ret);
+        uv_close((uv_handle_t*) &context->uvHandle, NULL);
+        Except_throw(exHandler, "uv_udp_recv_start() failed [%s]", err);
+    }
+
+    int nameLen = sizeof(struct Sockaddr_storage);
+    struct Sockaddr_storage ss;
+    Bits_memset(&ss, 0, sizeof(struct Sockaddr_storage));
+    ret = uv_udp_getsockname(&context->uvHandle, (void*)ss.nativeAddr, &nameLen);
+    if (ret) {
+        const char* err = uv_strerror(ret);
+        uv_close((uv_handle_t*) &context->uvHandle, NULL);
+        Except_throw(exHandler, "uv_udp_getsockname() failed [%s]", err);
+    }
+    ss.addr.addrLen = nameLen + 8;
+
+    context->pub.generic.addr = Sockaddr_clone(&ss.addr, alloc);
+    Log_debug(logger, "Bound to address [%s]", Sockaddr_print(context->pub.generic.addr, alloc));
+
+    context->devices = List_new(alloc);
+
+    if (devices) {
+        int32_t count = List_size(devices);
+        for (int32_t i = 0; i < count; i++) {
+            String* device = List_getString(devices, i);
+            List_addStringC(context->devices, device->bytes, alloc);
+        }
+    }
+
+    Allocator_onFree(alloc, closeHandleOnFree, context);
+    Allocator_onFree(alloc, blockFreeInsideCallback, context);
+
+    return &context->pub;
+}


### PR DESCRIPTION
Current cjdns support auto-peer feature in the same LAN by using ETHInterface, but it need root and not supported by windows, android, iOs or other platform. This commit will introduce the new auto-peer with neighbour by using UDP ipv4 broadcast function. 