### PR TITLE
s390x support for embedded cnacl

### DIFF
--- a/node_build/dependencies/cnacl/cpucycles/osfreq.c
+++ b/node_build/dependencies/cnacl/cpucycles/osfreq.c
@@ -33,6 +33,18 @@ static double osfreq(void)
   f = fopen("/proc/cpuinfo","r");
   if (f) {
     for (;;) {
+      s = fscanf(f,"cpu MHz dynamic : %lf",&result);
+      if (s > 0) break;
+      if (s == 0) s = fscanf(f,"%*[^\n]\n");
+      if (s < 0) { result = 0; break; }
+    }
+    fclose(f);
+    if (result) return 1000000.0 * result;
+  }
+
+  f = fopen("/proc/cpuinfo","r");
+  if (f) {
+    for (;;) {
       s = fscanf(f,"clock : %lf",&result);
       if (s > 0) break;
       if (s == 0) s = fscanf(f,"%*[^\n]\n");

--- a/node_build/dependencies/cnacl/do
+++ b/node_build/dependencies/cnacl/do
@@ -418,7 +418,7 @@ echo "=== `date` === starting curvecp"
 
 okabi \
 | awk '
-  { if ($1=="amd64" || $1=="ia64" || $1=="ppc64" || $1=="sparcv9" || $1=="mips64") print 1,$1
+  { if ($1=="amd64" || $1=="ia64" || $1=="ppc64" || $1=="sparcv9" || $1=="mips64" || $1=="s390x") print 1,$1
     else if ($1 == "mips32") print 2,$1
     else print 3,$1
   }

--- a/node_build/dependencies/cnacl/node_build/plans/s390x_plan.json
+++ b/node_build/dependencies/cnacl/node_build/plans/s390x_plan.json
@@ -1,0 +1,124 @@
+{
+  "PLAN_IMPLEMENTATIONS": [
+    [
+      "crypto_sign",
+      "ed25519",
+      "ref10"
+    ],
+    [
+      "crypto_stream",
+      "aes128ctr",
+      "portable"
+    ],
+    [
+      "crypto_auth",
+      "hmacsha256",
+      "ref"
+    ],
+    [
+      "crypto_core",
+      "hsalsa20",
+      "ref"
+    ],
+    [
+      "crypto_scalarmult",
+      "curve25519",
+      "ref"
+    ],
+    [
+      "crypto_core",
+      "salsa20",
+      "ref"
+    ],
+    [
+      "crypto_verify",
+      "16",
+      "ref"
+    ],
+    [
+      "crypto_onetimeauth",
+      "poly1305",
+      "donna"
+    ],
+    [
+      "crypto_core",
+      "salsa208",
+      "ref"
+    ],
+    [
+      "crypto_hashblocks",
+      "sha512",
+      "inplace"
+    ],
+    [
+      "crypto_stream",
+      "salsa2012",
+      "ref"
+    ],
+    [
+      "crypto_stream",
+      "xsalsa20",
+      "ref"
+    ],
+    [
+      "crypto_secretbox",
+      "xsalsa20poly1305",
+      "ref"
+    ],
+    [
+      "crypto_core",
+      "salsa2012",
+      "ref"
+    ],
+    [
+      "crypto_verify",
+      "32",
+      "ref"
+    ],
+    [
+      "crypto_stream",
+      "salsa208",
+      "ref"
+    ],
+    [
+      "crypto_hash",
+      "sha256",
+      "ref"
+    ],
+    [
+      "crypto_hashblocks",
+      "sha256",
+      "ref"
+    ],
+    [
+      "crypto_hash",
+      "sha512",
+      "ref"
+    ],
+    [
+      "crypto_box",
+      "curve25519xsalsa20poly1305",
+      "ref"
+    ],
+    [
+      "crypto_auth",
+      "hmacsha512256",
+      "ref"
+    ],
+    [
+      "crypto_stream",
+      "salsa20",
+      "ref"
+    ]
+  ],
+  "PLAN_TYPES": [
+    "typedef short crypto_int16;",
+    "typedef unsigned int crypto_uint32;",
+    "typedef unsigned short crypto_uint16;",
+    "typedef long long crypto_int64;",
+    "typedef int crypto_int32;",
+    "typedef unsigned char crypto_uint8;",
+    "typedef signed char crypto_int8;",
+    "typedef unsigned long long crypto_uint64;"
+  ]
+}

--- a/node_build/dependencies/cnacl/okcompilers/abiname.c
+++ b/node_build/dependencies/cnacl/okcompilers/abiname.c
@@ -14,6 +14,8 @@ const char *abi(void)
    return "ppc64";
 #elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) || defined(_ARCH_PPC)
    return "ppc32";
+#elif defined(__s390x__)
+   return "s390x"
 #elif defined(__sparcv9__) || defined(__sparcv9)
    return "sparcv9";
 #elif defined(__sparc_v8__)

--- a/node_build/dependencies/cnacl/okcompilers/abiname_xcompile.c
+++ b/node_build/dependencies/cnacl/okcompilers/abiname_xcompile.c
@@ -20,6 +20,8 @@
     #error ABI_IS_ppc64__
 #elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) || defined(_ARCH_PPC)
     #error ABI_IS_ppc32__
+#elif defined(__s390x__)
+    #error ABI_IS_s390x__
 #elif defined(__sparcv9__) || defined(__sparcv9)
     #error ABI_IS_sparcv9__
 #elif defined(__sparc_v8__)


### PR DESCRIPTION
s390x support from Fedora project.  This was added by s390x users of cjdns on Fedora - I have not personally tried it.  I have verified that it doesn't break x86_64.