### PR TITLE
Fix Python peerStats when results have more than 1 page

### DIFF
--- a/contrib/python/cjdnsadmin/adminTools.py
+++ b/contrib/python/cjdnsadmin/adminTools.py
@@ -102,7 +102,7 @@ def peerStats(cjdns,up=False,verbose=False,human_readable=False):
 
     i = 0;
     while True:
-        ps = cjdns.InterfaceController_peerStats(i);
+        ps = cjdns.InterfaceController_peerStats(page=i);
         peers = ps['peers']
         for p in peers:
             p.update(parseAddr(p['addr']))


### PR DESCRIPTION
I'm also reworking the Python interface argument parsing to allow optional arguments to be passed as required, so it can be less brittle if argument types are changed in the future. It still needs a bit of love; you can't mix name=value and value, value, value styles for required arguments like I think you ought to be able to. But this at least gets peerStats working again.