### PR TITLE
Fix memory leak when modify the CA auth user field

### DIFF
--- a/crypto/CryptoAuth.c
+++ b/crypto/CryptoAuth.c
@@ -1069,14 +1069,26 @@ void CryptoAuth_setAuth(const String* password,
         Identity_check((struct CryptoAuth_Session_pvt*)caSession);
 
     if (!password && (session->password || session->authType)) {
+        if (session->passwdAlloc) {
+            Allocator_free(session->passwdAlloc);
+            session->passwdAlloc = NULL;
+        }
         session->password = NULL;
         session->authType = 0;
     } else if (!session->password || !String_equals(session->password, password)) {
-        session->password = String_clone(password, session->alloc);
+        if (session->passwdAlloc) {
+            Allocator_free(session->passwdAlloc);
+        }
+        session->passwdAlloc = Allocator_child(session->alloc);
+        session->password = String_clone(password, session->passwdAlloc);
         session->authType = 1;
         if (login) {
             session->authType = 2;
-            session->login = String_clone(login, session->alloc);
+            if (session->loginAlloc) {
+                Allocator_free(session->loginAlloc);
+            }
+            session->loginAlloc = Allocator_child(session->alloc);
+            session->login = String_clone(login, session->loginAlloc);
         }
     } else {
         return;

--- a/crypto/CryptoAuth_pvt.h
+++ b/crypto/CryptoAuth_pvt.h
@@ -81,9 +81,11 @@ struct CryptoAuth_Session_pvt
     uint8_t ourTempPubKey[32];
 
     /** A password to use for authing with the other party. */
+    struct Allocator* passwdAlloc;
     String* password;
 
     /** The login name to auth with the other party. */
+    struct Allocator* loginAlloc;
     String* login;
 
     /** The next nonce to use. */


### PR DESCRIPTION
Current there is only beacon(see https://github.com/cjdelisle/cjdns/blob/master/net/InterfaceController.c#L586) will change the CA auth user field, malicious attacker might use this to exhaust the memory on host node.