### PR TITLE
Allow TIMEOUT to be overridden with TEST_TIMEOUT

### DIFF
--- a/node_build/TestRunner.js
+++ b/node_build/TestRunner.js
@@ -15,7 +15,7 @@ var Spawn = require('child_process').spawn;
 var Http = require("http");
 var Fs = require("fs");
 
-var TIMEOUT = 15000;
+var TIMEOUT = process.env.TEST_TIMEOUT || 15000;
 
 var parseURL = function (url)
 {

--- a/node_build/TestRunner.js
+++ b/node_build/TestRunner.js
@@ -15,7 +15,7 @@ var Spawn = require('child_process').spawn;
 var Http = require("http");
 var Fs = require("fs");
 
-var TIMEOUT = process.env.TEST_TIMEOUT || 15000;
+var TIMEOUT = process.env.TestRunner_TIMEOUT || 60000;
 
 var parseURL = function (url)
 {


### PR DESCRIPTION
This helps slower devices (such as single-board computers) compile successfully.