### PR TITLE
systemd run before network.target

### DIFF
--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=cjdns: routing engine designed for security, scalability, speed and ease of use
 Wants=network.target
-After=network.target
+After=network-pre.target
+Before=network.target network.service
 
 [Service]
 ProtectHome=true


### PR DESCRIPTION
opensmtpd cannot listen on ip6 (fc prefixed) at reboot. I found this change to fix the issue.
I'm running fedora 28.
cjdns.service runs successfully with this change. There might be other requirements which i didn't thought of.