### PR TITLE
Fix runit script

### DIFF
--- a/contrib/runit/run
+++ b/contrib/runit/run
@@ -3,4 +3,4 @@ set -e
 
 exec 2>&1
 sleep 5
-exec /usr/bin/cjdroute < /etc/cjdns/cjdroute.conf
+exec /usr/bin/cjdroute --nobg < /etc/cjdns/cjdroute.conf


### PR DESCRIPTION
Without --nobg argument added to run script, runit continuously tries to restart the daemon, thinking it's down.