### PR TITLE
README : add hyperboria map + peers links

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,9 @@ reasons:
    resolution.
 
 To find a friend, get out there and join our [community](#community). Also, have
-a look at the [Hyperboria Map][] to find peers near you.
+a look at the [Hyperboria Map](https://www.fc00.org/) to find peers near you.
 
+You can also use the geographically assorted list of public peering credentials for joining Hyperboria at [hyperboria/peers](https://github.com/hyperboria/peers).
 
 ### 3. Connect your node to your friend's node
 


### PR DESCRIPTION
This pull request brings a commit that adds a missing link about the `fc00` map, and copy and pastes an invitation to the public peering list.