### PR TITLE
Check if ret.nodes is defined first (traceroute)

### DIFF
--- a/tools/traceroute
+++ b/tools/traceroute
@@ -92,7 +92,7 @@ var main = function (target) {
         tracePath(target, self, cjdns, function (ret) {
             lastRet = ret;
             process.stdout.write('  ' + ret.ms + 'ms\n');
-            if (ret.nodes.length === 0) {
+            if (!ret.nodes || !ret.nodes.length) {
                 console.log('cornered');
             } else if (ret.nodes[0] !== ret.from) {
                 process.stdout.write(ret.nodes[0] + ' ' + highBits(ret.nodes[0]));
@@ -109,7 +109,7 @@ var main = function (target) {
             process.stdout.write('  ' + ret.ms + 'ms\n');
             if (ret.result === 'timeout') {
                 process.stdout.write('\n' + ret.from + ' ' + ret.result + '!');
-            } else if (ret.nodes.length === 0) {
+            } else if (!ret.nodes || !ret.nodes.length) {
                 console.log('cornered');
             } else if (ret.nodes[0] !== ret.from) {
                 process.stdout.write(ret.nodes[0] + ' ' + highBits(ret.nodes[0]));


### PR DESCRIPTION
I'm often getting following crash:
```
v20.0000.0000.0000.0001.xyug4j1fpqz87d7z6z5wfuly24yudwbh39qn3gslmz7vu3qndk60.k b882:93e5  1ms
v20.0000.0000.0000.0019.c6x0vfhh88ncz4by4ss3kmf09c7lp5nv9jufs8r3mkcudxfvb9v0.k 18da:0103  53ms
v20.0000.0000.0000.4249.bk44zumxqh26vs93yvpp3uuhcq5rxd891g8dugrd2lzntny1jbl0.k 5341:6940  3000ms
/opt/cjdns/tools/traceroute:95
            if (ret.nodes.length === 0) {
                          ^

TypeError: Cannot read property 'length' of undefined
    at /opt/cjdns/tools/traceroute:95:27
    at /opt/cjdns/tools/traceroute:49:13
    at Object.callback (/opt/cjdns/tools/lib/Semaphore.js:7:30)
    at Socket.<anonymous> (/opt/cjdns/tools/lib/cjdnsadmin/cjdnsadmin.js:191:17)
    at emitTwo (events.js:126:13)
    at Socket.emit (events.js:214:7)
    at UDP.onMessage [as onmessage] (dgram.js:659:8)
```

This PR should fix it.