### PR TITLE
Crashey

### DIFF
--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -694,7 +694,7 @@ int main(int argc, char** argv)
     struct Allocator* corePipeAlloc = Allocator_child(allocator);
     char corePipeName[64] = "client-core-";
     Random_base32(rand, (uint8_t*)corePipeName+CString_strlen(corePipeName), 31);
-    String* pipePath = Dict_getStringC(&config, "pipe");
+    String* pipePath = Dict_getStringC(config, "pipe");
     String path;
     if (!pipePath) {
         path = *String_CONST(Pipe_PATH);

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -694,6 +694,16 @@ int main(int argc, char** argv)
     struct Allocator* corePipeAlloc = Allocator_child(allocator);
     char corePipeName[64] = "client-core-";
     Random_base32(rand, (uint8_t*)corePipeName+CString_strlen(corePipeName), 31);
+    String* pipePath = Dict_getStringC(&config, "pipe");
+    String path;
+    if (!pipePath) {
+        path = String_CONST_V(Pipe_PATH);
+        pipePath = &path;
+    }
+    if (!Defined(win32) && access(pipePath->bytes, W_OK)) {
+        Except_throw(eh, "Pipe directory not writable: [%s]",pipePath->bytes);
+    }
+
     String* pipePath = Dict_getStringC(config, "pipe");
     if (!pipePath) {
         pipePath = String_CONST(Pipe_PATH);

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -697,7 +697,7 @@ int main(int argc, char** argv)
     String* pipePath = Dict_getStringC(&config, "pipe");
     String path;
     if (!pipePath) {
-        path = String_CONST_V(Pipe_PATH);
+        path = *String_CONST(Pipe_PATH);
         pipePath = &path;
     }
     if (!Defined(win32) && access(pipePath->bytes, W_OK)) {

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -695,10 +695,9 @@ int main(int argc, char** argv)
     char corePipeName[64] = "client-core-";
     Random_base32(rand, (uint8_t*)corePipeName+CString_strlen(corePipeName), 31);
     String* pipePath = Dict_getStringC(config, "pipe");
-    String path;
+    String* path = String_CONST(Pipe_PATH);
     if (!pipePath) {
-        path = *String_CONST(Pipe_PATH);
-        pipePath = &path;
+        pipePath = path;
     }
     if (!Defined(win32) && access(pipePath->bytes, W_OK)) {
         Except_throw(eh, "Pipe directory not writable: [%s]",pipePath->bytes);

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -704,13 +704,6 @@ int main(int argc, char** argv)
         Except_throw(eh, "Pipe directory not writable: [%s]",pipePath->bytes);
     }
 
-    String* pipePath = Dict_getStringC(config, "pipe");
-    if (!pipePath) {
-        pipePath = String_CONST(Pipe_PATH);
-    }
-    if (!Defined(win32) && access(pipePath->bytes, W_OK)) {
-        Except_throw(eh, "Can't have writable permission to pipe directory.");
-    }
     Assert_ifParanoid(EventBase_eventCount(eventBase) == 0);
     struct Pipe* corePipe = Pipe_named(pipePath->bytes, corePipeName, eventBase,
                                        eh, corePipeAlloc);


### PR DESCRIPTION
String_CONST takes address of temporary object which falls out of scope here.  All uses need to be examined, but this crashes on gcc-9.0.  