### PR TITLE
Fixed "critical" error if user "nobody" doesn't exist

### DIFF
--- a/client/Configurator.c
+++ b/client/Configurator.c
@@ -539,17 +539,6 @@ static void security(struct Allocator* tempAlloc, List* conf, struct Log* log, s
     int64_t* group = NULL;
     int keepNetAdmin = 1;
 
-    do {
-        Dict* d = Dict_new(tempAlloc);
-        Dict_putStringCC(d, "user", "nobody", tempAlloc);
-        if (!Defined(win32)) {
-            Dict* ret = NULL;
-            rpcCall0(String_CONST("Security_getUser"), d, ctx, tempAlloc, &ret, true);
-            uid = *Dict_getIntC(ret, "uid");
-            group = Dict_getIntC(ret, "gid");
-        }
-    } while (0);
-
     for (int i = 0; conf && i < List_size(conf); i++) {
         Dict* elem = List_getDict(conf, i);
         String* s;
@@ -601,6 +590,17 @@ static void security(struct Allocator* tempAlloc, List* conf, struct Log* log, s
             continue;
         }
         Log_info(ctx->logger, "Unrecognized entry in security at index [%d]", i);
+    }
+
+    if (uid == -1) {
+        Dict* d = Dict_new(tempAlloc);
+        Dict_putStringCC(d, "user", "nobody", tempAlloc);
+        if (!Defined(win32)) {
+            Dict* ret = NULL;
+            rpcCall0(String_CONST("Security_getUser"), d, ctx, tempAlloc, &ret, true);
+            uid = *Dict_getIntC(ret, "uid");
+            group = Dict_getIntC(ret, "gid");
+        }
     }
 
     if (chroot) {


### PR DESCRIPTION
Currently this happens:

    1558043149 CRITICAL Configurator.c:107 Got error [Could not find user [Success]] calling [Security_getUser]
    1558043149 CRITICAL Configurator.c:57 enable Log_LEVEL=KEYS to see message content.
    1558043149 CRITICAL Configurator.c:71 Aborting.

This happens because the ~~user~~ function `Security_getUser` was always called with `"nobody"` as argument and would always exit on error, even if another user is specified.

The fix is to simply move that code below the loop and check if `uid` is set.