### PR TITLE
Update LinuxRandomUuidSysctlRandomSeed.c

### DIFF
--- a/crypto/random/seed/LinuxRandomUuidSysctlRandomSeed.c
+++ b/crypto/random/seed/LinuxRandomUuidSysctlRandomSeed.c
@@ -20,6 +20,7 @@
 
 #include <unistd.h>
 #include <sys/syscall.h>
+#ifndef SYS_getrandom
 #include <sys/sysctl.h>
 
 static int getUUID(uint64_t output[2])
@@ -35,6 +36,7 @@ static int getUUID(uint64_t output[2])
     }
     return 0;
 }
+#endif
 
 static int get(struct RandomSeed* randomSeed, uint64_t output[8])
 {
@@ -48,11 +50,13 @@ static int get(struct RandomSeed* randomSeed, uint64_t output[8])
     if (ret == 64 && !Bits_isZero(output, 64)) {
         return 0;
     }
-#endif
+    return -1;
+#else
     if (getUUID(output) || getUUID(output+2) || getUUID(output+4) || getUUID(output+6)) {
         return -1;
     }
     return 0;
+#endif
 }
 
 struct RandomSeed* LinuxRandomUuidSysctlRandomSeed_new(struct Allocator* alloc)


### PR DESCRIPTION
Sysctl has been deprecated for some time, and current gcc is aggressive about flagging uses of it, causing cjdns builds to fail.  This patch simply removes sysctl.h and sysctl calls when SYS_getrandom is defined.  Any linux system that is modern enough to make a stink about sysctl calls, is also modern enough to have getrandom.