### PR TITLE
Pointer type fatal warning

### DIFF
--- a/util/events/libuv/Timeout.c
+++ b/util/events/libuv/Timeout.c
@@ -68,7 +68,7 @@ static void unlinkTo(struct Timeout* timeout)
 /**
  * The callback to be called by libuv.
  */
-static void handleEvent(uv_timer_t* handle)
+static void handleEvent(uv_timer_t* handle, int status)
 {
     struct Timeout* timeout = Identity_check((struct Timeout*) handle);
     if (!timeout->isArmed) { return; }


### PR DESCRIPTION
Actually I don't know if that pointer type is consistent either way, between libuv versions, but I know my version of libuv breaks the compile, so it either has to be changed, or some kind of #ifdef put in there to change the signature depending on libuv versions.

I'm so useful!