### PR TITLE
fix length limit

### DIFF
--- a/util/platform/netdev/NetPlatform_linux.c
+++ b/util/platform/netdev/NetPlatform_linux.c
@@ -78,7 +78,7 @@ static int socketForIfName(const char* interfaceName,
     }
 
     memset(ifRequestOut, 0, sizeof(struct ifreq));
-    strncpy(ifRequestOut->ifr_name, interfaceName, IFNAMSIZ);
+    strncpy(ifRequestOut->ifr_name, interfaceName, IFNAMSIZ-1);
 
     if (ioctl(s, SIOCGIFINDEX, ifRequestOut) < 0) {
         int err = errno;


### PR DESCRIPTION
```
Error: gcc -c -x cpp-output -o build_linux/util_platform_netdev_NetPlatform_linux_c.o -std=c99 -Wall -Wextra -Werror -Wno-pointer-sign -Wmissing-prototypes -pedantic -D linux=1 -D CJD_PACKAGE_VERSION="unknown" -Wno-unused-parameter -D Log_DEBUG -g -D NumberCompress_TYPE=v3x5x8 -D Identity_CHECK=1 -D Allocator_USE_CANARIES=1 -D PARANOIA=1 -march=native -DHAS_ETH_INTERFACE=1 -fPIE -march=armv8-a+crc+aes+sha2 -mcpu=cortex-a53+crc+aes+sha2 -O2 -pipe -march=armv8-a+crc+aes+sha2 -mcpu=cortex-a53+crc+aes+sha2 -O2 -pipe -march=armv8-a+crc+aes+sha2 -mcpu=cortex-a53+crc+aes+sha2 -O2 -pipe -D_FORTIFY_SOURCE=2 -fno-stack-protector -fstack-protector-all -Wstack-protector -O2 build_linux/util_platform_netdev_NetPlatform_linux_c.o.i

In file included from /usr/include/string.h:494,
                 from util/platform/netdev/NetPlatform_linux.c:24:
In function ‘strncpy’,
    inlined from ‘socketForIfName’ at util/platform/netdev/NetPlatform_linux.c:81:5:
/usr/include/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ specified bound 16 equals destination size [-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

    at error (/var/tmp/portage/net-misc/cjdns-20.4/work/cjdns-cjdns-v20.4/node_build/builder.js:53:15)
    at /var/tmp/portage/net-misc/cjdns-20.4/work/cjdns-cjdns-v20.4/node_build/builder.js:125:22
    at /var/tmp/portage/net-misc/cjdns-20.4/work/cjdns-cjdns-v20.4/node_build/builder.js:95:13
    at ChildProcess.<anonymous> (/var/tmp/portage/net-misc/cjdns-20.4/work/cjdns-cjdns-v20.4/tools/lib/Semaphore.js:7:30)
    at ChildProcess.emit (events.js:210:5)
    at maybeClose (internal/child_process.js:1021:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)
```
basically if strncpy truncates according to limit given, it won't include null terminator therefore gcc warns about that.
also fuck you for using `-Werror` and disabling issues.