### PR TITLE
util/platform/netdev: fix strncpy usages for BSDs and SunOS

### DIFF
--- a/util/platform/netdev/NetPlatform_freebsd.c
+++ b/util/platform/netdev/NetPlatform_freebsd.c
@@ -143,7 +143,7 @@ static void addIp6Address(const char* interfaceName,
         *cp = 0xff << (8 - len);
     }
 
-    strncpy(in6_addreq.ifra_name, interfaceName, sizeof(in6_addreq.ifra_name));
+    strncpy(in6_addreq.ifra_name, interfaceName, sizeof(in6_addreq.ifra_name)-1);
 
     /* do the actual assignment ioctl */
     int s = socket(AF_INET6, SOCK_DGRAM, 0);
@@ -192,8 +192,9 @@ void NetPlatform_setMTU(const char* interfaceName,
 
 
     struct ifreq ifRequest;
+    memset(&ifRequest, 0, sizeof(ifRequest));
 
-    strncpy(ifRequest.ifr_name, interfaceName, IFNAMSIZ);
+    strncpy(ifRequest.ifr_name, interfaceName, IFNAMSIZ-1);
     ifRequest.ifr_mtu = mtu;
 
     Log_info(logger, "Setting MTU for device [%s] to [%u] bytes.", interfaceName, mtu);

--- a/util/platform/netdev/NetPlatform_netbsd.c
+++ b/util/platform/netdev/NetPlatform_netbsd.c
@@ -90,7 +90,7 @@ static void addIp6Address(const char* interfaceName,
         *cp = 0xff << (8 - len);
     }
 
-    strncpy(in6_addreq.ifra_name, interfaceName, sizeof(in6_addreq.ifra_name));
+    strncpy(in6_addreq.ifra_name, interfaceName, sizeof(in6_addreq.ifra_name)-1);
 
     /* do the actual assignment ioctl */
     int s = socket(AF_INET6, SOCK_DGRAM, 0);
@@ -139,8 +139,9 @@ void NetPlatform_setMTU(const char* interfaceName,
 
 
     struct ifreq ifRequest;
+    memset(&ifRequest, 0, sizeof(ifRequest));
 
-    strncpy(ifRequest.ifr_name, interfaceName, IFNAMSIZ);
+    strncpy(ifRequest.ifr_name, interfaceName, IFNAMSIZ-1);
     ifRequest.ifr_mtu = mtu;
 
     Log_info(logger, "Setting MTU for device [%s] to [%u] bytes.", interfaceName, mtu);

--- a/util/platform/netdev/NetPlatform_openbsd.c
+++ b/util/platform/netdev/NetPlatform_openbsd.c
@@ -90,7 +90,7 @@ static void addIp6Address(const char* interfaceName,
         *cp = 0xff << (8 - len);
     }
 
-    strncpy(in6_addreq.ifra_name, interfaceName, sizeof(in6_addreq.ifra_name));
+    strncpy(in6_addreq.ifra_name, interfaceName, sizeof(in6_addreq.ifra_name)-1);
 
     /* do the actual assignment ioctl */
     int s = socket(AF_INET6, SOCK_DGRAM, 0);
@@ -139,8 +139,9 @@ void NetPlatform_setMTU(const char* interfaceName,
 
 
     struct ifreq ifRequest;
+    memset(&ifRequest, 0, sizeof(ifRequest));
 
-    strncpy(ifRequest.ifr_name, interfaceName, IFNAMSIZ);
+    strncpy(ifRequest.ifr_name, interfaceName, IFNAMSIZ-1);
     ifRequest.ifr_mtu = mtu;
 
     Log_info(logger, "Setting MTU for device [%s] to [%u] bytes.", interfaceName, mtu);

--- a/util/platform/netdev/NetPlatform_sunos.c
+++ b/util/platform/netdev/NetPlatform_sunos.c
@@ -121,7 +121,7 @@ static void addIp6Address(const char* interfaceName,
     struct sockaddr_in6* sin6 = (struct sockaddr_in6 *) &ifr.lifr_addr;
     maskForPrefix((uint8_t*) sin6->sin6_addr.s6_addr, prefixLen);
     ifr.lifr_addr.ss_family = AF_INET6;
-    strncpy(ifr.lifr_name, interfaceName, LIFNAMSIZ);
+    strncpy(ifr.lifr_name, interfaceName, LIFNAMSIZ-1);
 
     int udpSock = socket(AF_INET6, SOCK_DGRAM, 0);
     if (udpSock < 0) {


### PR DESCRIPTION
strncpy leaves destination buffer not terminated with '\0' if strlen(src)==dstlen.
also add memset in some places to zero destination structures, as strncpy would no longer touch last remaining byte.