### PR TITLE
Catch auth errors

### DIFF
--- a/tools/lib/cjdnsadmin/cjdnsadmin.js
+++ b/tools/lib/cjdnsadmin/cjdnsadmin.js
@@ -194,6 +194,7 @@ var connect = module.exports.connect = function (addr, port, pass, callback) {
     nThen(function (waitFor) {
         callFunc(sock, addr, port, pass, 'ping', {}, waitFor(function (err, ret) {
             if (err) { throw err; }
+            if (ret.error) { throw new Error(`Connect Error: ${ret.error}`) }
             //console.log("got pong! [" + JSON.stringify(ret) + "]");
         }));
     }).nThen(function (waitFor) {


### PR DESCRIPTION
When I log in with wrong credentials I get this error

```
{ error: 'Auth failed.', txid: '1621897404' }
/home/maciej/cjdns/tools/lib/cjdnsadmin/cjdnsadmin.js:150
                    Object.keys(ret.availableFunctions).forEach(function (funcName) {
                           ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at /home/maciej/cjdns/tools/lib/cjdnsadmin/cjdnsadmin.js:150:28
    at Object.callback (/home/maciej/cjdns/node_modules/nthen/index.js:21:22)
    at Socket.<anonymous> (/home/maciej/cjdns/tools/lib/cjdnsadmin/cjdnsadmin.js:192:17)
    at Socket.emit (events.js:311:20)
    at UDP.onMessage [as onmessage] (dgram.js:924:8)
```

Now it's this one

```
/home/maciej/cjdns/tools/lib/cjdnsadmin/cjdnsadmin.js:198
            if (ret.error) { throw new Error(`Connect Error: ${ret.error}`) }
                             ^

Error: Connect Error: Auth failed.
    at /home/maciej/cjdns/tools/lib/cjdnsadmin/cjdnsadmin.js:198:36
    at Object.callback (/home/maciej/cjdns/node_modules/nthen/index.js:21:22)
    at Socket.<anonymous> (/home/maciej/cjdns/tools/lib/cjdnsadmin/cjdnsadmin.js:192:17)
    at Socket.emit (events.js:311:20)
    at UDP.onMessage [as onmessage] (dgram.js:924:8)
```