### PR TITLE
AndroidWrapper implementation in Rust

### DIFF
--- a/interface/tuntap/AndroidWrapper.c
+++ b/interface/tuntap/AndroidWrapper.c
@@ -36,7 +36,7 @@ struct AndroidWrapper_pvt
     Identity
 };
 
-static Iface_DEFUN incomingFromWire(struct Message* msg, struct Iface* externalIf)
+Iface_DEFUN AndroidWrapper_incomingFromWire(struct Message* msg, struct Iface* externalIf)
 {
     struct AndroidWrapper_pvt* ctx =
         Identity_containerOf(externalIf, struct AndroidWrapper_pvt, pub.externalIf);
@@ -64,7 +64,7 @@ static Iface_DEFUN incomingFromWire(struct Message* msg, struct Iface* externalI
     return Iface_next(&ctx->pub.internalIf, msg);
 }
 
-static Iface_DEFUN incomingFromUs(struct Message* msg, struct Iface* internalIf)
+Iface_DEFUN AndroidWrapper_incomingFromUs(struct Message* msg, struct Iface* internalIf)
 {
     struct AndroidWrapper_pvt* ctx =
         Identity_containerOf(internalIf, struct AndroidWrapper_pvt, pub.internalIf);
@@ -77,16 +77,4 @@ static Iface_DEFUN incomingFromUs(struct Message* msg, struct Iface* internalIf)
     Er_assert(Message_eshift(msg, -4));
 
     return Iface_next(&ctx->pub.externalIf, msg);
-}
-
-struct AndroidWrapper* AndroidWrapper_new(struct Allocator* alloc, struct Log* log)
-{
-    struct AndroidWrapper_pvt* context =
-        Allocator_calloc(alloc, sizeof(struct AndroidWrapper_pvt), 1);
-    Identity_set(context);
-    context->pub.externalIf.send = incomingFromWire;
-    context->pub.internalIf.send = incomingFromUs;
-    context->logger = log;
-
-    return &context->pub;
 }

--- a/interface/tuntap/AndroidWrapper.h
+++ b/interface/tuntap/AndroidWrapper.h
@@ -29,4 +29,7 @@ struct AndroidWrapper
 
 struct AndroidWrapper* AndroidWrapper_new(struct Allocator* alloc, struct Log* log);
 
+Iface_DEFUN AndroidWrapper_incomingFromWire(struct Message* msg, struct Iface* externalIf);
+Iface_DEFUN AndroidWrapper_incomingFromUs(struct Message* msg, struct Iface* internalIf);
+
 #endif

--- a/rust/cjdns_sys/src/external/interface/iface.rs
+++ b/rust/cjdns_sys/src/external/interface/iface.rs
@@ -1,0 +1,30 @@
+//! Network interface from C part of the project.
+
+#![allow(non_camel_case_types, non_snake_case)]
+
+use crate::external::wire::error::*;
+use crate::external::wire::message::*;
+
+/// A network interface representation structure.
+///
+/// Corresponds to C `struct Iface` from `interface/Iface.h`.
+#[repr(C)]
+pub struct Iface {
+    /// Send a message through this interface.
+    pub send: Iface_Callback,
+
+    // The problem here is that this `cfg(PARANOIA)`
+    // does not automatically match C's preprocessor `#define PARANOIA`
+    // so had to be manually taken care of.
+    // In case of mismatch the C's and Rust's structures would not match either,
+    // and the universe will collapse.
+    /// This is for checking currentMsg Iface_next() has not been called incorrectly.
+    #[cfg(PARANOIA)]
+    currentMsg: *const Message,
+
+    /// Interface to which this one is connected (if connected).
+    connectedIf: *mut Iface,
+}
+
+pub type Iface_Callback =
+    unsafe extern "C" fn(message: *const Message, thisInterface: *mut Iface) -> Error_s;

--- a/rust/cjdns_sys/src/external/memory/allocator.rs
+++ b/rust/cjdns_sys/src/external/memory/allocator.rs
@@ -1,0 +1,64 @@
+//! Memory allocator from C part of the project.
+
+use std::ffi::c_void;
+use std::os::raw::c_char;
+
+/// External opaque C allocator type. Should be used in a form of a pointer only.
+#[repr(C)]
+pub struct Allocator {
+    _dummy: usize,
+}
+
+extern "C" {
+    pub fn Allocator__calloc(
+        alloc: *mut Allocator,
+        length: usize,
+        count: usize,
+        file_name: *const c_char,
+        line_num: u32,
+    ) -> *mut c_void;
+}
+
+/// Allocate some memory from this memory allocator.
+/// The allocation will be aligned on the size of a pointer, if you need further alignment then
+/// you must handle it manually.
+/// Memory location will be filled with 0 bytes.
+///
+/// * `$alloc` the memory allocator.
+/// * `$size` the number of bytes per element.
+/// * `$count` the number of elements in the allocation.
+/// * Returns a pointer to the newly allocated memory.
+///
+/// See also C `calloc()`.
+macro_rules! allocator_calloc {
+    ($alloc: expr, $length: expr, $count: expr) => {{
+        use std::ffi::CString;
+        let file_name = CString::new(file!())
+            .expect("CString::new() failed")
+            .as_ptr();
+        let line_num = line!();
+        unsafe {
+            $crate::external::memory::allocator::Allocator__calloc(
+                $alloc, $length, $count, file_name, line_num,
+            )
+        }
+    }};
+}
+
+/// Allocate memory for the struct from this memory allocator.
+/// The allocation will be aligned on the size of a pointer, if you need further alignment then
+/// you must handle it manually.
+/// Memory location will be filled with 0 bytes.
+///
+/// * `$alloc` the memory allocator.
+/// * `$ty` the type (struct) that needs to be allocated.
+/// * Returns a pointer to the newly allocated struct.
+///
+/// See also [`allocator_calloc`] macro.
+macro_rules! allocator_calloc_struct {
+    ($alloc: expr, $ty: ty) => {{
+        let length = std::mem::size_of::<$ty>();
+        let ptr = allocator_calloc!($alloc, length, 1);
+        ptr as *mut $ty
+    }};
+}

--- a/rust/cjdns_sys/src/external/util/identity.rs
+++ b/rust/cjdns_sys/src/external/util/identity.rs
@@ -1,0 +1,15 @@
+//! Identity debugging utils.
+//!
+//! Not yet properly implemented.
+
+use std::ffi::c_void;
+
+/// External opaque C Identity type. Should be used in a form of a pointer only.
+pub struct Identity;
+
+impl Identity {
+    #[inline]
+    pub fn set(_: *mut c_void) {
+        // Not implemented
+    }
+}

--- a/rust/cjdns_sys/src/external/util/log.rs
+++ b/rust/cjdns_sys/src/external/util/log.rs
@@ -1,0 +1,7 @@
+//! Logger from C part of the project.
+
+/// External opaque C logger type. Should be used in a form of a pointer only.
+#[repr(C)]
+pub struct Log {
+    _dummy: usize,
+}

--- a/rust/cjdns_sys/src/external/wire/error.rs
+++ b/rust/cjdns_sys/src/external/wire/error.rs
@@ -1,0 +1,59 @@
+//! Error type from C part of the project.
+
+#![allow(non_camel_case_types)]
+
+/// Error structure.
+///
+/// Corresponds to C `struct Error_s` from `wire/Error.h`.
+#[repr(C)]
+pub struct Error_s {
+    e: Error_e,
+}
+
+/// Error enum.
+///
+/// Corresponds to C `enum Error_e` from `wire/Error.h`.
+#[repr(C)]
+pub enum Error_e {
+    /// No error, everything is ok.
+    Error_NONE = 0,
+
+    /// The switch label was malformed.
+    Error_MALFORMED_ADDRESS = 1,
+
+    /// Packet dropped because link is congested.
+    Error_FLOOD = 2,
+
+    /// Packet dropped because node has oversent its limit.
+    Error_LINK_LIMIT_EXCEEDED = 3,
+
+    /// Message too big to send.
+    Error_OVERSIZE_MESSAGE = 4,
+
+    /// Message smaller than expected headers.
+    Error_RUNT = 5,
+
+    /// Authentication failed.
+    Error_AUTHENTICATION = 6,
+
+    /// Header is invalid or checksum failed.
+    Error_INVALID = 7,
+
+    /// Message could not be sent to its destination through no fault of the sender.
+    Error_UNDELIVERABLE = 8,
+
+    /// The route enters and leaves through the same interface in one switch.
+    Error_LOOP_ROUTE = 9,
+
+    /// The switch is unable to represent the return path.
+    Error_RETURN_PATH_INVALID = 10,
+
+    /// Not invalid, but not something the code is able to handle.
+    Error_UNHANDLED = 11,
+
+    /// Too many messages, cannot handle.
+    Error_OVERFLOW = 12,
+
+    /// Something went wrong, it should not have happened.
+    Error_INTERNAL = 13,
+}

--- a/rust/cjdns_sys/src/external/wire/message.rs
+++ b/rust/cjdns_sys/src/external/wire/message.rs
@@ -1,0 +1,42 @@
+//! Message type from C part of the project.
+
+#![allow(non_snake_case)]
+
+use std::os::raw::c_int;
+
+use crate::external::memory::allocator::*;
+
+/// A network message.
+///
+/// Corresponds to C `struct Message` from `wire/Message.h`.
+#[repr(C)]
+pub struct Message {
+    /// The length of the message.
+    pub length: i32,
+
+    /// The number of bytes of padding BEFORE where bytes begins.
+    pub padding: i32,
+
+    /// The content.
+    pub bytes: *const u8,
+
+    /// Amount of bytes of storage space available in the message.
+    pub capacity: i32,
+
+    /// When sending/receiving a Message on a unix socket, a file descriptor to attach.
+    /// Caveat: In order to maintain backward compatibility with a Message which is
+    /// allocated using calloc, file descriptor 0 is referred to by -1
+    pub associatedFd: c_int,
+
+    // The problem here is that this `cfg(PARANOIA)`
+    // does not automatically match C's preprocessor `#define PARANOIA`
+    // so had to be manually taken care of.
+    // In case of mismatch the C's and Rust's structures would not match either,
+    // and the universe will collapse.
+    /// This is used inside of Iface.h to support Iface_next()
+    #[cfg(PARANOIA)]
+    pub currentIface: *const crate::external::interface::iface::Iface,
+
+    /// The allocator which allocated space for this message.
+    pub alloc: *mut Allocator,
+}

--- a/rust/cjdns_sys/src/interface/tuntap/android.rs
+++ b/rust/cjdns_sys/src/interface/tuntap/android.rs
@@ -1,0 +1,47 @@
+//! Android wrapper
+//!
+//! Android VpnService is expect you to read/write packet from the tun device
+//! file description opened by system process rather than in the cjd process,
+//! this InterfaceWrapper handle this case.
+
+#![allow(non_camel_case_types, non_snake_case)]
+
+use std::ffi::c_void;
+
+use crate::external::interface::iface::*;
+use crate::external::memory::allocator::*;
+use crate::external::util::identity::*;
+use crate::external::util::log::*;
+use crate::external::wire::error::*;
+use crate::external::wire::message::*;
+
+#[repr(C)]
+pub struct AndroidWrapper {
+    internalIf: Iface,
+    externalIf: Iface,
+}
+
+#[repr(C)]
+struct AndroidWrapper_pvt {
+    public: AndroidWrapper,
+    logger: *mut Log,
+    identity: Identity,
+}
+
+extern "C" {
+    fn AndroidWrapper_incomingFromWire(msg: *const Message, externalIf: *mut Iface) -> Error_s;
+    fn AndroidWrapper_incomingFromUs(msg: *const Message, internalIf: *mut Iface) -> Error_s;
+}
+
+#[no_mangle]
+pub extern "C" fn AndroidWrapper_new(alloc: *mut Allocator, log: *mut Log) -> *mut AndroidWrapper {
+    let context = allocator_calloc_struct!(alloc, AndroidWrapper_pvt);
+    Identity::set(context as *mut c_void);
+    let p = unsafe { &mut (*context).public };
+    p.externalIf.send = AndroidWrapper_incomingFromWire;
+    p.internalIf.send = AndroidWrapper_incomingFromUs;
+    unsafe {
+        (*context).logger = log;
+    }
+    p as *mut AndroidWrapper
+}

--- a/rust/cjdns_sys/src/lib.rs
+++ b/rust/cjdns_sys/src/lib.rs
@@ -22,3 +22,30 @@ macro_rules! c_main {
         }
     };
 }
+
+/// All the C implementations are gathered under this `external` module.
+#[macro_use]
+pub mod external {
+    pub mod interface {
+        pub mod iface;
+    }
+    #[macro_use]
+    pub mod memory {
+        #[macro_use]
+        pub mod allocator;
+    }
+    pub mod util {
+        pub mod identity;
+        pub mod log;
+    }
+    pub mod wire {
+        pub mod error;
+        pub mod message;
+    }
+}
+
+mod interface {
+    pub mod tuntap {
+        pub mod android;
+    }
+}


### PR DESCRIPTION
Proof-of-concept AndroidWrapper implementation in Rust

* Rust interface to basic C impl's stuff like logging and memory allocation
* No implementation for "identity" stuff - not sure what is it and how is it used
* No good solution for C's `#define` vs Rust's `#[cfg()]` yet
* Rust implementation of the android wrapper (function calls from C to Rust and vice versa)
* Builds without errors
* Not yet tested on actual Android device