### PR TITLE
docs: Fix a few typos

### DIFF
--- a/dht/dhtcore/NodeStore.c
+++ b/dht/dhtcore/NodeStore.c
@@ -1393,7 +1393,7 @@ static struct Node_Link* discoverNode(struct NodeStore_pvt* store,
         } while (firstHopInPath_INVALID != path);
 
         if (lastLink && LabelSplicer_routesThrough(addr->path, lastLink->child->address.path)) {
-            // checking for sillyness...
+            // checking for silliness...
             Assert_true(lastLink != store->selfLink);
             NodeStore_unlinkNodes(&store->pub, lastLink);
             continue;

--- a/dht/dhtcore/RouterModule.c
+++ b/dht/dhtcore/RouterModule.c
@@ -466,7 +466,7 @@ static int handleIncoming(struct DHTMessage* message, void* vcontext)
 
     struct RouterModule* module = Identity_check((struct RouterModule*) vcontext);
 
-    // This is retreived below by onResponseOrTimeout()
+    // This is retrieved below by onResponseOrTimeout()
     module->currentMessage = message;
     Pinger_pongReceived(txid, module->pinger);
     module->currentMessage = NULL;

--- a/doc/Whitepaper.md
+++ b/doc/Whitepaper.md
@@ -902,7 +902,7 @@ assuming they are not “too late” and are not replays.
 To do that, it stores a 64-bit bitfield, with a bit for each of the 64
 nonces before the highest nonce received so far.
 Every time a packet is received with a nonce between `highestnonce - 64`
-(excluded) and `highestnonce` (included), it substracts the packet's nonce
+(excluded) and `highestnonce` (included), it subtracts the packet's nonce
 to the highest nonce, giving a number n, and looks at the n-th bit
 of the bitfield. If it is one, the packet is a replay and is dropped.
 If it is zero, the packet passes, and the bit is set to one.

--- a/util/ArrayList.h
+++ b/util/ArrayList.h
@@ -22,7 +22,7 @@ Linker_require("util/ArrayList.c")
 
 /*
  * This struct is never defined anywhere.
- * It's used in place to void* so that casts must be explicit to reduce likelyhood of error.
+ * It's used in place to void* so that casts must be explicit to reduce likelihood of error.
  */
 struct ArrayList;
 

--- a/util/Set.h
+++ b/util/Set.h
@@ -24,7 +24,7 @@ Linker_require("util/Set.c")
 
 /*
  * This struct is never defined anywhere.
- * It's used in place to void* so that casts must be explicit to reduce likelyhood of error.
+ * It's used in place to void* so that casts must be explicit to reduce likelihood of error.
  */
 struct Set;
 struct Set_Iter;


### PR DESCRIPTION
There are small typos in:
- dht/dhtcore/NodeStore.c
- dht/dhtcore/RouterModule.c
- doc/Whitepaper.md
- util/ArrayList.h
- util/Set.h

Fixes:
- Should read `likelihood` rather than `likelyhood`.
- Should read `subtracts` rather than `substracts`.
- Should read `silliness` rather than `sillyness`.
- Should read `retrieved` rather than `retreived`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md