### PR TITLE
fix rust compile errors

### DIFF
--- a/rust/cjdns_sys/src/interface/wire/message.rs
+++ b/rust/cjdns_sys/src/interface/wire/message.rs
@@ -1,6 +1,7 @@
 //! Message type.
 
 use std::slice::{from_raw_parts, from_raw_parts_mut};
+use std::i32;
 
 use thiserror::Error;
 


### PR DESCRIPTION
Without this change the following build errors happen:

```
error[E0599]: no associated item named `MAX` found for type `i32` in the current scope
   --> rust/cjdns_sys/src/interface/wire/message.rs:103:36
    |
103 |         debug_assert!(count < i32::MAX as usize);
    |                                    ^^^ associated item not found in `i32`
    |
help: you are looking for the module in `std`, not the primitive type
    |
103 |         debug_assert!(count < std::i32::MAX as usize);
    |                               ^^^^^^^^^^^^^

error[E0599]: no associated item named `MAX` found for type `i32` in the current scope
   --> rust/cjdns_sys/src/interface/wire/message.rs:117:36
    |
117 |         debug_assert!(count < i32::MAX as usize);
    |                                    ^^^ associated item not found in `i32`
    |
help: you are looking for the module in `std`, not the primitive type
    |
117 |         debug_assert!(count < std::i32::MAX as usize);
    |                               ^^^^^^^^^^^^^

error[E0599]: no associated item named `MAX` found for type `i32` in the current scope
   --> rust/cjdns_sys/src/interface/wire/message.rs:153:35
    |
153 |         debug_assert!(size < i32::MAX as usize);
    |                                   ^^^ associated item not found in `i32`
    |
help: you are looking for the module in `std`, not the primitive type
    |
153 |         debug_assert!(size < std::i32::MAX as usize);
    |                              ^^^^^^^^^^^^^

error[E0599]: no associated item named `MAX` found for type `i32` in the current scope
   --> rust/cjdns_sys/src/interface/wire/message.rs:182:35
    |
182 |         debug_assert!(size < i32::MAX as usize);
    |                                   ^^^ associated item not found in `i32`
    |
help: you are looking for the module in `std`, not the primitive type
    |
182 |         debug_assert!(size < std::i32::MAX as usize);
    |                              ^^^^^^^^^^^^^

error: aborting due to 4 previous errors

For more information about this error, try `rustc --explain E0599`.
error: could not compile `cjdns_sys`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```