### PR TITLE
READMEs translation and reindexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ scalability issues that plague existing networks.
 
 ## Community
 
-* [irc://irc.freenode.org/#cjdns][IRC Web]
+* [irc://irc.efnet.org/#cjdns][IRC Web]
 * [Hyperboria][] the largest cjdns network, as of October 2015 there are 2100 nodes.
 * [/r/darknetplan][]
 * [#cjdns on Twitter][]

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ If you need to build from source, everything you need can be installed like this
     pacman -S nodejs git base-devel
 
 Alternatively, you may like to install via AUR from the package, `cjdns-git`.
-After Installation, The configuration file is located at `/etc/cjdroute.conf`.
+After installation, the configuration file is located at `/etc/cjdroute.conf`.
 To start the service `cjdns.service`, do:
 
     systemctl start cjdns

--- a/README_DE.md
+++ b/README_DE.md
@@ -8,6 +8,7 @@
 [繁體中文](README_ZHT.md)
 [Español](README_ES.md)
 [Français](README_FR.md)
+[Português brasileiro](README_PT-BR.md)
 
 #### *Netzwerk neu erfunden*
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -17,7 +17,7 @@ la asignación de direcciones y una tabla distribuida de hashes para el
 ruteo. Esto provee redes de casi-nula-configuración, y previene mucho de los
 problemas de seguridad y escalabilidad que plagan a las redes existentes.
 
-[![Build Status](https://travis-ci.org/cjdelisle/cjdns.svg?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
+[![Build Status](https://api.travis-ci.org/cjdelisle/cjdns.svg?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/387/badge)](https://bestpractices.coreinfrastructure.org/projects/387)
 [![tip for next commit](https://tip4commit.com/projects/941.svg)](https://tip4commit.com/github/cjdelisle/cjdns)
 [![irc](https://img.shields.io/badge/irc%20chat-%23cjdns-blue.svg)](https://kiwiirc.com/client/irc.efnet.org/?nick=visitor|?#cjdns)

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,13 +1,14 @@
 # cjdns
 
+[English](README.md)
 [Русская версия](README_RU.md)
 [Hrvatski](README_HR.md)
 [Svenska](README_SV.md)
 [Ελληνικά](README_GR.md)
 [Deutsch](README_DE.md)
 [繁體中文](README_ZHT.md)
-[Español](README_ES.md)
 [Français](README_FR.md)
+[Português brasileiro](README_PT-BR.md)
 
 #### *Reinventando las redes*
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -2,6 +2,7 @@ Traduction à partir de la version
 [`cjdns-v19.1`](https://github.com/woshilapin/cjdns/blob/cjdns-v19.1/README.md)
 # cjdns
 
+[English](README.md)
 [Русская версия](README_RU.md)
 [Hrvatski](README_HR.md)
 [Svenska](README_SV.md)
@@ -9,7 +10,7 @@ Traduction à partir de la version
 [Deutsch](README_DE.md)
 [繁體中文](README_ZHT.md)
 [Español](README_ES.md)
-[Français](README_FR.md)
+[Português brasileiro](README_PT-BR.md)
 
 #### *Le réseau réinventé*
 

--- a/README_GR.md
+++ b/README_GR.md
@@ -18,8 +18,10 @@ Cjdns υλοποιεί ένα κρυπτογραφημένο δίκτυο IPV6 �
 επεκτασιμότητας που μαστίζουν τα υπάρχοντα δίκτυα.
 
 [![Build Status](https://api.travis-ci.org/cjdelisle/cjdns.svg?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/387/badge)](https://bestpractices.coreinfrastructure.org/projects/387)
 [![tip for next commit](https://tip4commit.com/projects/941.svg)](https://tip4commit.com/github/cjdelisle/cjdns)
 [![irc](https://img.shields.io/badge/irc%20chat-%23cjdns-blue.svg)](https://kiwiirc.com/client/irc.efnet.org/?nick=visitor|?#cjdns)
+![License](https://img.shields.io/github/license/cjdelisle/cjdns.svg)
 
 ## Γνώμες πελατών
 

--- a/README_GR.md
+++ b/README_GR.md
@@ -130,6 +130,16 @@ Cjdns υλοποιεί ένα κρυπτογραφημένο δίκτυο IPV6 �
 
     pacman -S nodejs git base-devel
 
+Εναλλακτικά, μπορείτε να το εγκαταστήσετε μέσω του AUR από το πακέτο, `cjdns-git`.
+Μετά την εγκατάσταση, το αρχείο ρυθμίσεων βρίσκεται στην τοποθεσία `/etc/cjdroute.conf`.
+Για να ξεκινήσετε το service `cjdns.service`, κάντε:
+
+    systemctl start cjdns
+
+Για να το σταματήσετε:
+
+    systemctl stop cjdns
+
 #### Gentoo:
 
 Το cjdns δεν βρίσκεται ακόμα στο κύριο εναποθετήριο του Gentoo, οπότε θα χρειαστεί να χρησιμοποιήσετε το ένα overlay.

--- a/README_GR.md
+++ b/README_GR.md
@@ -8,6 +8,7 @@
 [繁體中文](README_ZHT.md)
 [Español](README_ES.md)
 [Français](README_FR.md)
+[Português brasileiro](README_PT-BR.md)
 
 #### *Η δικτύωση επανεφευρέθηκε*
 

--- a/README_GR.md
+++ b/README_GR.md
@@ -130,11 +130,89 @@ Cjdns υλοποιεί ένα κρυπτογραφημένο δίκτυο IPV6 �
 
     pacman -S nodejs git base-devel
 
+#### Gentoo:
+
+Το cjdns δεν βρίσκεται ακόμα στο κύριο εναποθετήριο του Gentoo, οπότε θα χρειαστεί να χρησιμοποιήσετε το ένα overlay.
+Ο ευκολότερος τρόπος είναι να χρησιμοποιήσετε το Layman αλλά μπορείτε και χειροκίνητα επίσης.
+
+##### Layman:
+
+Πρώτα, θα χρειαστεί να εγκαταστήσετε το layman.
+
+    emerge layman
+
+Αν το layman εγκαταστάθηκε σωστά, μπορείτε να προσθέσετε το overlay
+
+    layman -f
+    layman -a weuxel
+
+Για μελλοντικές αναβαθμίσεις του overlay χρησιμοποιήστε
+
+    layman -S
+
+Τώρα μπορείτε να εγκαταστήσετε το cjdns
+
+    emerge cjdns
+
+##### Χειροκίνητα:
+
+Κλωνοποιήστε το εναποθετήριο του overlay
+
+    cd /opt
+    git clone https://github.com/Weuxel/portage-weuxel.git
+
+Πείτε στο portage να χρησιμοποιήσει το εναποθετήριο
+
+    cd /etc/portage/repos.conf/
+
+Δημιουργήστε ένα αρχείο με όνομα `portage-weuxel.conf` που να περιέχει
+
+    [weuxel]
+    location = /opt/portage-weuxel
+    masters = gentoo
+    auto-sync = yes
+
+Τώρα συγχρονίστε
+
+    emerge --sync
+
+Και εγκαταστήστε το cjdns
+
+    emerge cjdns
+
+#### Αυτόματος έλεγχος διακοπής λειτουργίας και επανεκκίνηση
+
+Αντιγράψτε το openrc init script από `contrib/openrc` στο φάκελο `/etc/init.d/` και αλλάξτε τις παραμέτρους `CONFFILE` και `command` σύμφωνα με τις ανάγκες σας.
+Μετά ξεκινήστε το cjdns πληκτρολογώντας
+
+    /etc/init.d/cjdns start
+
+Ρυθμίστε το init system ώστε να ξεκινά το cjdns αυτόματα
+
+    rc-update add cjdns default
+
+Αντιγράψτε το service_restart script `contrib/gentoo/service_restart.sh` σε οποιονδήποτε φάκελο πιστεύτε πως θα έπρεπε να βρίσκεται στο
+σύστημά σας και αλλάξτε τη διεύθυνση eMail. Αν δε θέλετε να ειδοποιήστε, μαρκάρετε τη γραμμή ως σχόλιο.
+Τώρα προσθέστε μια εγγραφή στο crontab με αυτό τον τρόπο
+
+    # Restart crashed Services
+    * * * * *       root    /path/to/script/service_restart.sh
+
+#### Solus:
+
+Εξαρτήσεις:
+
+    sudo eopkg install nodejs git build-essential system.devel python gcc binutils kernal-headers xorg-server-devel
+
+Ακολουθήστε τα βήματα παρακάτω:
+
+*Ζητούμε συγγνώμη για τα τόσα πολλά βήματα. Προετοιμάζεται ένα πακέτο*
+
 ### 1. Ανακτήστε το cjdns από το GitHub
 
 Κλωνοποίηστε το αποθετήριο από το GitHub και περάστε στο πηγαίο φάκελο:
 
-    git clone https://github.com/cjdelisle/cjdns.git
+    git clone https://github.com/cjdelisle/cjdns.git cjdns
     cd cjdns
 
 ### 2. Χτίστε
@@ -376,6 +454,19 @@ TUN/TAP συσκευή - αυτό είναι στάνταρ πρωτόκολλο
 * την **Python library**; δείτε [εδώ](contrib/python/README.md).
 * την **Perl library**, συντηρείται από τον Mikey; δείτε [εδώ](contrib/perl/CJDNS/README).
 
+## Αναφορά προβλημάτων
+1. Μην αναφέρετε σε αυτό το εναποθετήριο, αντ' αυτού παρακαλούμε αναφέρετέ το στο https://github.com/hyperboria/bugs/issues
+2. Μπείτε στο IRC και μιλήστε με κάποιο
+3. Το τι μπορεί να συμβεί είναι είτε
+ * κάποιος μπορεί να το φτιάξει
+ * εσείς μπορείτε να το φτιάξετε
+ * κανείς δεν ασχολείτε και παραμένει ξεχασμένο μέχρι κάποιος να πέσει πάνω του αργότερα και το φτιάξει ή απλά θα χαθεί σε κάποιο ανασχεδιασμό
+ * κανείς δε μπορεί να το φτιάξει εκείνη τη στιγμή αλλά είναι σημαντικό να το θυμόμαστε γιατί έχει μεγάλη σημασία στον τρόπο που δημιουργείται ο κώδικας, σε αυτή την περίπτωση χρειάζεται να εξηγηθεί με τεχνικούς όρους από κάποιον που είναι οικείος με τον κώδικα. Μπορούν να κάνουν κάποιο pull request στο φάκελο docs/bugs.
+
+### Ασφάλεια
+Τα προβλήματα ασφαλείας θα πρέπει να αναφέρονται στο IRC όπως και τα υπόλοιπα bugs. Δεν έχουμε κάποιο κλειστό group ανθρώπων με εξειδικευμένη γνώση οπότε αυτό σημαίνει πως η προεπιλεγμένη μέθοδος αναφοράς προβλημάτων ασφαλείας είναι η πλήρης περιγραφή.
+
+Δείτε: [security_specification.md](https://github.com/cjdelisle/cjdns/blob/master/doc/security_specification.md) ώστε να καταλάβετε αν ένα πιθανό πρόβλημα ασφάλεια είναι πραγματικά πρόβλημα ασφάλειας.
 
 [IRC Web]: http://chat.efnet.org/irc.cgi?chan=%23cjdns
 [Hyperboria]: https://hyperboria.net

--- a/README_HR.md
+++ b/README_HR.md
@@ -18,7 +18,10 @@ mrežnu konfiguraciju i sprječava mnoge sigurnosne i
 skalabilne probleme koje muče trenutne mreže.
 
 [![Build Status](https://api.travis-ci.org/cjdelisle/cjdns.svg?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/387/badge)](https://bestpractices.coreinfrastructure.org/projects/387)
 [![napojnica za sljedeću promjenu](https://tip4commit.com/projects/941.svg)](https://tip4commit.com/github/cjdelisle/cjdns)
+[![irc](https://img.shields.io/badge/irc%20chat-%23cjdns-blue.svg)](https://kiwiirc.com/client/irc.efnet.org/?nick=visitor|?#cjdns)
+![License](https://img.shields.io/github/license/cjdelisle/cjdns.svg)
 
 ## Iskustva
 

--- a/README_HR.md
+++ b/README_HR.md
@@ -8,6 +8,7 @@
 [繁體中文](README_ZHT.md)
 [Español](README_ES.md)
 [Français](README_FR.md)
+[Português brasileiro](README_PT-BR.md)
 
 #### *Umrežavanje iznova*
 

--- a/README_HR.md
+++ b/README_HR.md
@@ -39,7 +39,7 @@ skalabilne probleme koje muče trenutne mreže.
 
 ## Zajednica
 
-* irc://irc.efnet.org/#cjdns ([web client][IRC Web])
+* [irc://irc.efnet.org/#cjdns][IRC Web]
 * [Hyperboria][]
 * [Projekt Meshnet][]
 * [/r/darknetplan][]

--- a/README_PT-BR.md
+++ b/README_PT-BR.md
@@ -1,5 +1,6 @@
 # cjdns
 
+[English](README.md)
 [Русская версия](README_RU.md)
 [Hrvatski](README_HR.md)
 [Svenska](README_SV.md)
@@ -8,7 +9,6 @@
 [繁體中文](README_ZHT.md)
 [Español](README_ES.md)
 [Français](README_FR.md)
-[Português brasileiro](README_PT-BR.md)
 
 #### *Rede Reinventada*
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -8,6 +8,7 @@
 [繁體中文](README_ZHT.md)
 [Español](README_ES.md)
 [Français](README_FR.md)
+[Português brasileiro](README_PT-BR.md)
 
 Безопасная, зашифрованная сеть для обычных людей.
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -14,8 +14,11 @@
 
 Cjdns — это зашифрованная IPv6 сеть, в которой используются публичные ключи шифрования для присвоения публичного адреса и распределённой таблицы маршрутизации (DHT). Это позволяет создавать сети с очень простой настройкой, которые будут защищены от потенциальных проблем ныне существующих IPv4 и IPv6 сетей.
 
-[![Build Status](https://api.travis-ci.org/cjdelisle/cjdns.png?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
-[![For next commit](https://tip4commit.com/projects/941.svg)](https://tip4commit.com/github/cjdelisle/cjdns)
+[![Build Status](https://api.travis-ci.org/cjdelisle/cjdns.svg?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/387/badge)](https://bestpractices.coreinfrastructure.org/projects/387)
+[![tip for next commit](https://tip4commit.com/projects/941.svg)](https://tip4commit.com/github/cjdelisle/cjdns)
+[![irc](https://img.shields.io/badge/irc%20chat-%23cjdns-blue.svg)](https://kiwiirc.com/client/irc.efnet.org/?nick=visitor|?#cjdns)
+![License](https://img.shields.io/github/license/cjdelisle/cjdns.svg)
 
 ## Рекомендательные письма
 

--- a/README_SV.md
+++ b/README_SV.md
@@ -18,9 +18,11 @@ hashtabell (DHT, eller Distributed Hash Table på engelska). Genom denna design
 uppnås ett nätverk som knappt kräver någon konfiguration. Vi blir också av med
 många skalnings- och säkerhetsproblem som andra nätverk har.
 
-[![Build Status](https://travis-ci.org/cjdelisle/cjdns.svg?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
+[![Build Status](https://api.travis-ci.org/cjdelisle/cjdns.svg?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/387/badge)](https://bestpractices.coreinfrastructure.org/projects/387)
 [![tip for next commit](https://tip4commit.com/projects/941.svg)](https://tip4commit.com/github/cjdelisle/cjdns)
 [![irc](https://img.shields.io/badge/irc%20chat-%23cjdns-blue.svg)](https://kiwiirc.com/client/irc.efnet.org/?nick=visitor|?#cjdns)
+![License](https://img.shields.io/github/license/cjdelisle/cjdns.svg)
 
 ## Vitsord
 

--- a/README_SV.md
+++ b/README_SV.md
@@ -8,6 +8,7 @@
 [繁體中文](README_ZHT.md)
 [Español](README_ES.md)
 [Français](README_FR.md)
+[Português brasileiro](README_PT-BR.md)
 
 #### *Datornätverk - Ett nytt sätt*
 

--- a/README_ZHT.md
+++ b/README_ZHT.md
@@ -14,10 +14,11 @@
 
 Cjdns 利用「加密的IPv6」及「公鑰加密」來分配網路地址並利用「Distributed Hash Table」逕行路由。它能提供近似「零配置網路（Zero-Configuration Networking）」，並且能防範在現有網路中存在的很多和安全、可擴展性相關的問題。
 
-[![Build Status](https://travis-ci.org/cjdelisle/cjdns.svg?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
+[![Build Status](https://api.travis-ci.org/cjdelisle/cjdns.svg?branch=master)](https://travis-ci.org/cjdelisle/cjdns)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/387/badge)](https://bestpractices.coreinfrastructure.org/projects/387)
 [![tip for next commit](https://tip4commit.com/projects/941.svg)](https://tip4commit.com/github/cjdelisle/cjdns)
 [![irc](https://img.shields.io/badge/irc%20chat-%23cjdns-blue.svg)](https://kiwiirc.com/client/irc.efnet.org/?nick=visitor|?#cjdns)
+![License](https://img.shields.io/github/license/cjdelisle/cjdns.svg)
 
 ## 評價
 

--- a/README_ZHT.md
+++ b/README_ZHT.md
@@ -1,4 +1,3 @@
-
 # cjdns
 
 [English](README.md)
@@ -9,6 +8,7 @@
 [Deutsch](README_DE.md)
 [Español](README_ES.md)
 [Français](README_FR.md)
+[Português brasileiro](README_PT-BR.md)
 
 #### *重朔整個網路*
 


### PR DESCRIPTION
I noticed IRC link had a wrong label, I started digging around so I decided to sync the language bar across the different languages. I did the same for the badges. I then translated in greek the gentoo and solus installation section, security and issue reporting sections that were missing. Also extended the arch linux installation techniques up to README.md. I can recheck the rest of readmes for missing parts and report them but, for example, I don't know chinese :laughing: 