### PR TITLE
Libuv remove step3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -256,6 +256,7 @@ dependencies = [
  "hex",
  "log",
  "parking_lot 0.11.1",
+ "pnet_datalink",
  "slog",
  "sodiumoxide",
  "thiserror",
@@ -466,6 +467,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,9 +524,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libloading"
@@ -568,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniz_oxide"
@@ -685,6 +695,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
+name = "pnet_base"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8205fe084bd43a3af79b3155c19feddd62e733640498842e631a2ffe107d1538"
+
+[[package]]
+name = "pnet_datalink"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f85aef5e52e22ff06b1b11f2eb6d52959a9e0ecad3cb3f5cc2d78cadc077f0e"
+dependencies = [
+ "ipnetwork",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028c87a5e3a48fc07df099a2025f2ef16add5993712e1494ba69a6707ee7ed06"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,9 +731,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -707,9 +746,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -781,21 +820,20 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -953,9 +991,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
  "hex",
  "log",
  "parking_lot 0.11.1",
- "pnet_datalink",
+ "pnet",
  "slog",
  "sodiumoxide",
  "thiserror",
@@ -695,6 +695,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
+name = "pnet"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8750e073f82219c01e771133c64718d7685aef922da8a0d430a46aed05b6341a"
+dependencies = [
+ "ipnetwork",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
+]
+
+[[package]]
 name = "pnet_base"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +728,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pnet_macros"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc3af95fed6dc318dfede3e81320f96ad5e237c6f7c4688108b19c8e67432d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feaba58ba96abb218ec584d6caf0d3ff48922df05dbbeb1560553c197091b29e"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f246edaaf1aaf82072d4cd38ee18bcc5dfc0464093f9ca39e4ac5962d68cf9d4"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
 name = "pnet_sys"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +768,18 @@ checksum = "028c87a5e3a48fc07df099a2025f2ef16add5993712e1494ba69a6707ee7ed06"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950f2a7961e19d22e19e84ff0a6e0955013185fe149673499662633d02b41b7a"
+dependencies = [
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
 ]
 
 [[package]]

--- a/memory/Allocator.h
+++ b/memory/Allocator.h
@@ -53,7 +53,7 @@ struct Allocator_OnFreeJob
  * In traditional C, each call to malloc() must be traced to a corresponding free() call, a
  * laborious process which can be partially automated but inevitably leaves some memory leak
  * investigative work to the developer. Allocator attempts to move the memory freeing operations
- * close to the memory allocations thus making bugs easy to spot without searching over large
+ * close to the memory allocations, thus making bugs easy to spot without searching over large
  * amounts of code.
  *
  * With Allocator, you might do the following:
@@ -69,11 +69,11 @@ struct Allocator_OnFreeJob
  *
  * #1 Do not create new root allocators, create child allocators instead.
  * When you call MallocAllocator_new() or equivalent, you are creating a parentless allocator and
- * you must take responsibility for it's freeing when you are finished with it. In cjdns there is
+ * you must take responsibility for its freeing when you are finished with it. In cjdns there is
  * only one call to a main allocator and all other allocators are spawned from it using
  * Allocator_child().
  * Exception: In certain code which interfaces with libuv, an alternate root allocator is necessary
- *    because libuv teardown process is asynchronous and memory used by libuv must not be freed
+ *    because libuv teardown process is asynchronous, and memory used by libuv must not be freed
  *    until this is complete.
  *
  * #2 Free your allocators and not anyone else's.
@@ -82,7 +82,7 @@ struct Allocator_OnFreeJob
  * things lying around expecting someone else to clean up after you. Sometimes you want to "take
  * ownership" of some memory which somebody else allocated and they are passing to you. Rather
  * than slowly allocate your own memory and copy the data over, you can use Allocator_adopt() to
- * hold that memory in existance until you and the creator both are finished with it.
+ * hold that memory in existence until you and the creator both are finished with it.
  *
  * #3 Assume that any allocator may be freed at any time.
  * A typical example is the ping message. When a ping is sent, a structure is allocated to hold

--- a/rust/cjdns_sys/Cargo.toml
+++ b/rust/cjdns_sys/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "1.0"
 anyhow = { version = "1.0", features = ["backtrace"] }
 boringtun = { git = "https://github.com/cjdelisle/boringtun", rev = "9dd253904616ff5327267cc4073dcf61e60b858e", version = "0.3", features = ["additional_data"] }
 slog = { version = "2.7", features = ["release_max_level_trace"] }
+pnet_datalink = "0.29"
 
 [build_dependencies]
 cc = "1.0"

--- a/rust/cjdns_sys/Cargo.toml
+++ b/rust/cjdns_sys/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0"
 anyhow = { version = "1.0", features = ["backtrace"] }
 boringtun = { git = "https://github.com/cjdelisle/boringtun", rev = "9dd253904616ff5327267cc4073dcf61e60b858e", version = "0.3", features = ["additional_data"] }
 slog = { version = "2.7", features = ["release_max_level_trace"] }
-pnet_datalink = "0.29"
+pnet = "0.29"
 
 [build_dependencies]
 cc = "1.0"

--- a/rust/cjdns_sys/Rffi.h
+++ b/rust/cjdns_sys/Rffi.h
@@ -15,8 +15,9 @@ typedef struct {
 
 typedef struct {
   const char *name;
+  uint8_t phys_addr[6];
   bool is_internal;
-  Rffi_Address addr;
+  Rffi_Address address;
 } Rffi_NetworkInterface;
 
 extern const uintptr_t Rffi_CURRENT_PROTOCOL;

--- a/rust/cjdns_sys/Rffi.h
+++ b/rust/cjdns_sys/Rffi.h
@@ -7,6 +7,18 @@
 
 typedef struct RTypes_CryptoAuth2_t RTypes_CryptoAuth2_t;
 
+typedef struct {
+  uint8_t octets[16];
+  uint8_t netmask[16];
+  bool is_ipv6;
+} Rffi_Address;
+
+typedef struct {
+  const char *name;
+  bool is_internal;
+  Rffi_Address addr;
+} Rffi_NetworkInterface;
+
 extern const uintptr_t Rffi_CURRENT_PROTOCOL;
 
 RTypes_IfWrapper_t Rffi_testwrapper_create(Allocator_t *a);
@@ -97,5 +109,10 @@ uint64_t Rffi_hrtime(void);
  * Monotonic millisecond time.
  */
 uint64_t Rffi_now_ms(void);
+
+/**
+ * Get a list of available network interfaces for the current machine.
+ */
+int32_t Rffi_interface_addresses(const Rffi_NetworkInterface **out, Allocator_t *alloc);
 
 #endif /* rffi_H */

--- a/rust/cjdns_sys/src/rffi.rs
+++ b/rust/cjdns_sys/src/rffi.rs
@@ -458,16 +458,16 @@ fn now_unix_epoch() -> Duration {
         .unwrap()
 }
 
-static mut BASE_INSTANT: Option<Instant> = None;
-static mut INSTANT_OFFSET: u64 = 0;
-static INIT: Once = Once::new();
-
 /// Monotonic millisecond time.
 #[no_mangle]
 pub unsafe extern "C" fn Rffi_now_ms() -> u64 {
+    static mut BASE_INSTANT: Option<Instant> = None;
+    static mut INSTANT_OFFSET: u64 = 0;
+    static INIT: Once = Once::new();
     INIT.call_once(|| {
         BASE_INSTANT = Some(Instant::now());
         INSTANT_OFFSET = now_unix_epoch().as_millis() as u64;
     });
+
     (Instant::now() - BASE_INSTANT.unwrap()).as_millis() as u64 + INSTANT_OFFSET
 }

--- a/rust/cjdns_sys/src/rffi.rs
+++ b/rust/cjdns_sys/src/rffi.rs
@@ -524,3 +524,25 @@ pub unsafe extern "C" fn Rffi_interface_addresses(
     *out = (*allocator::adopt(alloc, nis)).as_mut_ptr();
     count as _
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::external::memory::allocator::Allocator;
+
+    #[test]
+    fn test_interface_addresses() {
+        let alloc = Allocator::new(10000000);
+
+        let out = unsafe {
+            let mut x: *const Rffi_NetworkInterface = std::ptr::null();
+            let xp = &mut x as *mut *const Rffi_NetworkInterface;
+            let count = Rffi_interface_addresses(xp, alloc.native);
+            std::slice::from_raw_parts(x, count as _)
+        };
+
+        let ifs = pnet::datalink::interfaces();
+        let count = ifs.iter().map(|ni| ni.ips.len()).sum::<usize>();
+        assert_eq!(count, out.len());
+    }
+}


### PR DESCRIPTION
- new Rffi_interface_addresses
- unit test for Rffi_interface_addresses
- update C code, to use the new Rffi_interface_addresses, removing libuv
- includes pnet: a cross-platform API for low level networking using Rust
