### PR TITLE
Libuv remove step4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cbindgen"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +266,7 @@ dependencies = [
  "slog",
  "sodiumoxide",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -593,6 +600,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +629,15 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -619,6 +657,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -687,6 +735,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pkg-config"
@@ -995,6 +1049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1202,34 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tokio"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -770,7 +770,7 @@ int cjdroute2_main(int argc, char** argv)
     if (!privateKey) {
         Except_throw(eh, "Need to specify privateKey.");
     }
-    Process_spawn(corePath, args, eventBase, allocator, onCoreExit);
+    Process_spawn(corePath, args, allocator, onCoreExit);
 
     // --------------------- Wait for socket ------------------------- //
     // cycle for up to 1 minute

--- a/rust/cjdns_sys/Cargo.toml
+++ b/rust/cjdns_sys/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { version = "1.0", features = ["backtrace"] }
 boringtun = { git = "https://github.com/cjdelisle/boringtun", rev = "9dd253904616ff5327267cc4073dcf61e60b858e", version = "0.3", features = ["additional_data"] }
 slog = { version = "2.7", features = ["release_max_level_trace"] }
 pnet = "0.29"
+tokio = { version = "1", features = ["macros","time","sync","fs","rt-multi-thread","process"], default-features = false }
 
 [build_dependencies]
 cc = "1.0"

--- a/rust/cjdns_sys/Rffi.h
+++ b/rust/cjdns_sys/Rffi.h
@@ -117,4 +117,13 @@ int32_t Rffi_interface_addresses(const Rffi_NetworkInterface **out, Allocator_t 
  */
 int32_t Rffi_exepath(const char **out, Allocator_t *alloc);
 
+/**
+ * Spawn a new child process, and monitors its result.
+ */
+int32_t Rffi_spawn(const char *file,
+                   const char *const *args,
+                   int num_args,
+                   Allocator_t *_alloc,
+                   void (*cb)(long, int));
+
 #endif /* rffi_H */

--- a/rust/cjdns_sys/Rffi.h
+++ b/rust/cjdns_sys/Rffi.h
@@ -88,16 +88,12 @@ RTypes_Error_t *Rffi_error_fl(const char *msg, const char *file, int line, Alloc
 const char *Rffi_printError(RTypes_Error_t *e, Allocator_t *alloc);
 
 /**
- * Replaces libuv's function:
- *
- * int uv_inet_ntop(int af, const void* src, char* dst, size_t size)
+ * Convert IPv4 and IPv6 addresses from binary to text form.
  */
 int32_t Rffi_inet_ntop(bool is_ip6, const void *addr, uint8_t *dst, uint32_t dst_sz);
 
 /**
- * Replaces libuv's function:
- *
- * int uv_inet_pton(int af, const char* src, void* dst) {
+ * Convert IPv4 and IPv6 addresses from text to binary form.
  */
 int32_t Rffi_inet_pton(bool is_ip6, const char *src, uint8_t *addr);
 
@@ -115,5 +111,10 @@ uint64_t Rffi_now_ms(void);
  * Get a list of available network interfaces for the current machine.
  */
 int32_t Rffi_interface_addresses(const Rffi_NetworkInterface **out, Allocator_t *alloc);
+
+/**
+ * Get the full filesystem path of the current running executable.
+ */
+int32_t Rffi_exepath(const char **out, Allocator_t *alloc);
 
 #endif /* rffi_H */

--- a/rust/cjdns_sys/src/lib.rs
+++ b/rust/cjdns_sys/src/lib.rs
@@ -1,28 +1,34 @@
-// This is needed to make sure the linker will pull in sodium here
-pub fn init_sodium() {
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int};
+
+pub fn rust_main(cmain: unsafe extern "C" fn(c_int, *const *mut c_char)) {
+    cjdnslog::install();
     sodiumoxide::init().unwrap();
+    if std::env::var("RUST_BACKTRACE").is_err() {
+        std::env::set_var("RUST_BACKTRACE", "1");
+    }
+
+    let c_args = std::env::args()
+        .map(|arg| CString::new(arg).unwrap().into_raw())
+        .collect::<Vec<_>>();
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async { unsafe { cmain(c_args.len() as c_int, c_args.as_ptr()) } })
 }
 
 #[macro_export]
 macro_rules! c_main {
     ($cmain:ident) => {
-        use std::ffi::CString;
-        use std::os::raw::c_char;
-        use std::os::raw::c_int;
+        use std::os::raw::{c_char, c_int};
         extern "C" {
             fn $cmain(argc: c_int, argv: *const *mut c_char);
         }
         fn main() {
-            cjdns_sys::cjdnslog::install();
-            cjdns_sys::init_sodium();
-            if std::env::var("RUST_BACKTRACE").is_err() {
-                std::env::set_var("RUST_BACKTRACE", "1");
-            }
-            let c_args = std::env::args()
-                .map(|arg| CString::new(arg).unwrap())
-                .map(|arg| arg.into_raw())
-                .collect::<Vec<*mut c_char>>();
-            unsafe { $cmain(c_args.len() as c_int, c_args.as_ptr()) }
+            cjdns_sys::rust_main($cmain)
         }
     };
 }

--- a/rust/cjdns_sys/src/rffi.rs
+++ b/rust/cjdns_sys/src/rffi.rs
@@ -525,6 +525,17 @@ pub unsafe extern "C" fn Rffi_interface_addresses(
     count as _
 }
 
+/// Get the full filesystem path of the current running executable.
+#[no_mangle]
+pub unsafe extern "C" fn Rffi_exepath(out: *mut *const c_char, alloc: *mut Allocator_t) -> i32 {
+    let path = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return -1,
+    };
+    *out = str_to_c(path.to_string_lossy().as_ref(), alloc);
+    0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/cjdns_sys/src/rffi.rs
+++ b/rust/cjdns_sys/src/rffi.rs
@@ -400,9 +400,7 @@ pub unsafe extern "C" fn Rffi_printError(
         .unwrap_or_else(std::ptr::null)
 }
 
-/// Replaces libuv's function:
-///
-/// int uv_inet_ntop(int af, const void* src, char* dst, size_t size)
+/// Convert IPv4 and IPv6 addresses from binary to text form.
 #[no_mangle]
 pub unsafe extern "C" fn Rffi_inet_ntop(
     is_ip6: bool,
@@ -426,9 +424,7 @@ pub unsafe extern "C" fn Rffi_inet_ntop(
     0
 }
 
-/// Replaces libuv's function:
-///
-/// int uv_inet_pton(int af, const char* src, void* dst) {
+/// Convert IPv4 and IPv6 addresses from text to binary form.
 #[no_mangle]
 pub unsafe extern "C" fn Rffi_inet_pton(is_ip6: bool, src: *const c_char, addr: *mut u8) -> i32 {
     let src = CStr::from_ptr(src).to_string_lossy();

--- a/rust/cjdns_sys/src/rffi.rs
+++ b/rust/cjdns_sys/src/rffi.rs
@@ -556,4 +556,21 @@ mod tests {
         let count = ifs.iter().map(|ni| ni.ips.len()).sum::<usize>();
         assert_eq!(count, out.len());
     }
+
+    #[test]
+    fn test_exepath() -> anyhow::Result<()> {
+        let alloc = Allocator::new(10000000);
+
+        let out = unsafe {
+            let mut x: *const c_char = std::ptr::null();
+            let xp = &mut x as *mut *const c_char;
+            let err = Rffi_exepath(xp, alloc.native);
+            assert_eq!(err, 0);
+            CStr::from_ptr(x).to_str()
+        }?;
+
+        let path = std::env::current_exe()?;
+        assert_eq!(out, &path.to_string_lossy());
+        Ok(())
+    }
 }

--- a/util/events/Process.h
+++ b/util/events/Process.h
@@ -28,14 +28,12 @@ typedef void (* Process_OnExitCallback)(int64_t exit_status, int term_signal);
  *
  * @param binaryPath the path to the file to execute.
  * @param args a list of strings representing the arguments to the command followed by NULL.
- * @param base the event base.
  * @param alloc an allocator. The process to be killed when it is freed.
  * @param callback a function to be called when the spawn process exits.
  * @return 0 if all went well, -1 if forking fails.
  */
 int Process_spawn(char* binaryPath,
                   char** args,
-                  struct EventBase* base,
                   struct Allocator* alloc,
                   Process_OnExitCallback callback);
 

--- a/util/events/libuv/Process.c
+++ b/util/events/libuv/Process.c
@@ -13,6 +13,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "util/events/libuv/UvWrapper.h"
+#include "rust/cjdns_sys/Rffi.h"
 #include "memory/Allocator.h"
 #include "util/events/libuv/EventBase_pvt.h"
 #include "util/events/Process.h"
@@ -92,11 +93,10 @@ int Process_spawn(char* binaryPath,
 
 char* Process_getPath(struct Allocator* alloc)
 {
-    char path[4096];
-    size_t sz = 4096;
-    uv_exepath(path, &sz);
-    char* out = Allocator_malloc(alloc, sz+1);
-    Bits_memcpy(out, path, sz);
-    out[sz] = 0;
+    char* out;
+    int ret = Rffi_exepath(&out, alloc);
+    if (ret < 0) {
+        out = 0;
+    }
     return out;
 }

--- a/util/events/libuv/Process.c
+++ b/util/events/libuv/Process.c
@@ -12,83 +12,21 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "util/events/libuv/UvWrapper.h"
 #include "rust/cjdns_sys/Rffi.h"
 #include "memory/Allocator.h"
-#include "util/events/libuv/EventBase_pvt.h"
 #include "util/events/Process.h"
 #include "util/Bits.h"
 #include "util/Identity.h"
 
-struct Process_pvt
-{
-    uv_process_t proc;
-    Process_OnExitCallback onExit;
-    struct Allocator* alloc;
-    Identity
-};
-
-static void onFree2(uv_handle_t* process)
-{
-    Allocator_onFreeComplete((struct Allocator_OnFreeJob*) process->data);
-}
-
-static int onFree(struct Allocator_OnFreeJob* job)
-{
-    struct Process_pvt* p = Identity_check((struct Process_pvt*) job->userData);
-    uv_process_kill(&p->proc, SIGTERM);
-    p->proc.data = job;
-    uv_close((uv_handle_t*)&p->proc, onFree2);
-    return Allocator_ONFREE_ASYNC;
-}
-
-static void onExit(uv_process_t *req, int64_t exit_status, int term_signal)
-{
-    struct Process_pvt* p = Identity_containerOf(req, struct Process_pvt, proc);
-    if (p->onExit) {
-        p->onExit(exit_status, term_signal);
-    }
-}
-
 int Process_spawn(char* binaryPath,
                   char** args,
-                  struct EventBase* base,
                   struct Allocator* alloc,
                   Process_OnExitCallback callback)
 {
-    struct EventBase_pvt* ctx = EventBase_privatize(base);
-
     int i;
     for (i = 0; args[i]; i++) ;
-    char** binAndArgs = Allocator_calloc(alloc, sizeof(char*), i+2);
-    for (i = 0; args[i]; i++) {
-        binAndArgs[i+1] = args[i];
-    }
-    binAndArgs[0] = binaryPath;
-    binAndArgs[i+1] = NULL;
 
-    struct Process_pvt* p = Allocator_calloc(alloc, sizeof(struct Process_pvt), 1);
-    p->alloc = alloc;
-    Identity_set(p);
-    Allocator_onFree(alloc, onFree, p);
-
-    uv_stdio_container_t files[] = {
-        { .flags = UV_IGNORE },
-        { .flags = UV_INHERIT_FD, .data.fd = 1 },
-        { .flags = UV_INHERIT_FD, .data.fd = 2 },
-    };
-    uv_process_options_t options = {
-        .file = binaryPath,
-        .args = binAndArgs,
-        .flags = UV_PROCESS_WINDOWS_HIDE,
-        .stdio = files,
-        .stdio_count = 3,
-        .exit_cb = onExit
-    };
-
-    p->onExit = callback;
-
-    return uv_spawn(ctx->loop, &p->proc, &options);
+    return Rffi_spawn(binaryPath, args, i, alloc, callback);
 }
 
 char* Process_getPath(struct Allocator* alloc)

--- a/util/test/Process_test.c
+++ b/util/test/Process_test.c
@@ -189,7 +189,7 @@ int main(int argc, char** argv)
 
     char* args[] = { "Process_test", "child", name->bytes, NULL };
 
-    Assert_true(!Process_spawn(path, args, eb, alloc, NULL));
+    Assert_true(!Process_spawn(path, args, alloc, NULL));
 
     Timeout_setTimeout(timeout, NULL, 2000, eb, alloc);
 

--- a/util/test/Seccomp_test.c
+++ b/util/test/Seccomp_test.c
@@ -138,7 +138,7 @@ int main(int argc, char** argv)
     char* path = Process_getPath(alloc);
     char* args[] = { "Seccomp_test", "child", name->bytes, NULL };
 
-    Assert_true(!Process_spawn(path, args, eb, alloc, NULL));
+    Assert_true(!Process_spawn(path, args, alloc, NULL));
 
     Timeout_setTimeout(timeout2, NULL, 2000, eb, alloc);
 


### PR DESCRIPTION
- implements `Rffi_exepath` and `Rffi_spawn`
- instantiate a new tokio async Runtime in every binary
- change Process.c to use the new Rffi equivalents
- change Process_spawn signature to remove eventBase
- change every call site of the above function