### PR TITLE
Add riscv64 support

### DIFF
--- a/rust/cjdns_sys/Cargo.toml
+++ b/rust/cjdns_sys/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-sodiumoxide = { git = "https://github.com/cjdelisle/sodiumoxide", rev = "9f6a18d40a4db253edfebac9f2ce5c22d09b1f47", version = "0.2", default-features = false, features = ["std"] }
+sodiumoxide = { git = "https://github.com/cjdelisle/sodiumoxide", rev = "f79b6656b84f02b049470f9ad556a6a0c9980bd7", version = "0.2", default-features = false, features = ["std"] }
 cjdns-keys = { git = "https://github.com/CJDNS-Development-Team/CJDNS", version = "0.1.0" }
 cjdns-crypto = { git = "https://github.com/CJDNS-Development-Team/CJDNS", version = "0.1.0" }
 hex = "0.4"

--- a/util/ArchInfo.c
+++ b/util/ArchInfo.c
@@ -53,6 +53,7 @@ gcc arch.c
 #define ArchInfo_AUDIT_ARCH_IA64 0xc0000032
 #define ArchInfo_AUDIT_ARCH_PARISC 0x0000000f
 #define ArchInfo_AUDIT_ARCH_MIPS64 0x80000008
+#define ArchInfo_AUDIT_ARCH_RISCV64 0xc00000f3
 #define ArchInfo_AUDIT_ARCH_PPC64LE 0xc0000015
 #define ArchInfo_AUDIT_ARCH_ALPHA 0xc0009026
 #define ArchInfo_AUDIT_ARCH_MIPSEL 0x40000008
@@ -155,6 +156,9 @@ gcc arch.c
 #elif defined(__s390x__)
     #define ARCH ArchInfo_AUDIT_ARCH_S390X
     #define ARCHSTR "s390x"
+#elif defined(__riscv) && __riscv_xlen == 64
+    #define ARCH ArchInfo_AUDIT_ARCH_RISCV64
+    #define ARCHSTR "riscv64"
 #else
     #error architecture unknown
 #endif


### PR DESCRIPTION
- Add riscv64 entry in util/ArchInfo.c
- Link to newer version of cjdelisle/sodiumoxide (https://github.com/cjdelisle/sodiumoxide/pull/1) which provides riscv64 build fix