### PR TITLE
make.js: trim excess whitespaces from CFLAGS and LDFLAGS

### DIFF
--- a/node_build/make.js
+++ b/node_build/make.js
@@ -144,7 +144,7 @@ Builder.configure({
     // with NEON on the BBB, or want to set -Os (OpenWrt)
     // Allow -O0 so while debugging all variables are present.
     if (CFLAGS) {
-        var cflags = CFLAGS.split(' ');
+        var cflags = CFLAGS.split.trim().split(/\s+/);
         cflags.forEach(function (flag) {
             if (/^\-O[^02s]$/.test(flag)) {
                 console.log("Skipping " + flag + ", assuming " + optimizeLevel + " instead.");
@@ -164,7 +164,7 @@ Builder.configure({
     // We also need to pass various architecture/floating point flags to GCC when invoked as
     // a linker.
     if (LDFLAGS) {
-        [].push.apply(builder.config.ldflags, LDFLAGS.split(' '));
+        [].push.apply(builder.config.ldflags, LDFLAGS.trim().split(/\s+/));
     }
 
     if (android) {


### PR DESCRIPTION
Excess whitespaces in the CFLAGS and LDFLAGS variables cause `gcc` compilation errors like `aarch64-unknown-linux-gnu-gcc: error: No such file or directory`. This is hard to debug and happens because the `.split(' ')` function will create empty `gcc` arguments, if there are any excess whitespaces in the CFLAGS and LDFLAGS environment variables. This can happen when cross-compiling using a 3rd party toolchain, which manipulates/sets the CFLAGS/LDFLAGS variables and accidentally/carelessly puts to many whitespaces in these flags. We better `trim` any whitespaces from the beginning and end of CFLAGS/LDFLAGS strings and match consecutive whitespaces within the strings via a regex instead, to avoid these nasty and hard to spot compilation errors.