### PR TITLE
Fixed script to copy the files from the target/release directory

### DIFF
--- a/contrib/simple-install/cjdns-installer.sh
+++ b/contrib/simple-install/cjdns-installer.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 cp cjdroute /usr/bin/
-cp makekeys /usr/bin/
-cp mkpasswd /usr/bin/
-cp privatetopublic /usr/bin/
-cp publictoip6 /usr/bin/
-cp randombytes /usr/bin/
-cp sybilsim /usr/bin/
+cp target/release/makekeys /usr/bin/
+cp target/release/mkpasswd /usr/bin/
+cp target/release/privatetopublic /usr/bin/
+cp target/release/publictoip6 /usr/bin/
+cp target/release/randombytes /usr/bin/
+cp target/release/sybilsim /usr/bin/
 cp contrib/systemd/cjdns.service /etc/systemd/system/
 cp contrib/systemd/cjdns-resume.service /etc/systemd/system
 systemctl enable --now cjdns.service


### PR DESCRIPTION
Since the build system moved to Rust and cargo, the following output executables moved to the directory `target/release`:
- `makekeys`
- `mkpasswd`
- `privatetopublic`
- `publictoip6`
- `randombytes`
- `sybilsim`

This patch updates the `contrib/simple-install/cjdns-installer.sh` to copy the files from the new places they are output to.