### PR TITLE
Updated the places where the binaries are copied from

### DIFF
--- a/contrib/simple-install/README.md
+++ b/contrib/simple-install/README.md
@@ -1,12 +1,12 @@
 # Simple install
 
-Tested on ubuntu 18.04LTS
+Tested on ubuntu 18.04LTS, Fedora 35+
 
 ```
 git clone https://github.com/cjdelisle/cjdns.git
 cd cjdns/
 ./do
-sudo ./contrib/simple-install/cjdns-installer.sh
+sudo sh ./contrib/simple-install/cjdns-installer.sh
 ```
 
 You can edit configuration in `/etc/cjdroute.conf` and restart cjdns service with `sudo systemctl restart cjdns.service`.

--- a/contrib/simple-install/cjdns-installer.sh
+++ b/contrib/simple-install/cjdns-installer.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-cp cjdroute /usr/bin/
-cp makekeys /usr/bin/
-cp mkpasswd /usr/bin/
-cp privatetopublic /usr/bin/
-cp publictoip6 /usr/bin/
-cp randombytes /usr/bin/
-cp sybilsim /usr/bin/
+cp ./cjdroute /usr/bin/
+cp ./target/release/makekeys /usr/bin/
+cp ./target/release/mkpasswd /usr/bin/
+cp ./target/release/privatetopublic /usr/bin/
+cp ./target/release/publictoip6 /usr/bin/
+cp ./target/release/randombytes /usr/bin/
+cp ./target/release/sybilsim /usr/bin/
 cp contrib/systemd/cjdns.service /etc/systemd/system/
 cp contrib/systemd/cjdns-resume.service /etc/systemd/system
 systemctl enable --now cjdns.service


### PR DESCRIPTION
Copies from ./target/release the binaries produced there instead of the repository's root that were laying before.