### PR TITLE
fix incompatible function pointer types issue

### DIFF
--- a/util/events/libuv/Process.c
+++ b/util/events/libuv/Process.c
@@ -18,6 +18,11 @@
 #include "util/Bits.h"
 #include "util/Identity.h"
 
+void Process_OnExitCallbackWrapper(long pid, int exitCode) {
+    long long pidLongLong = (long long) pid;
+    Process_OnExitCallback(pidLongLong, exitCode);
+}
+
 int Process_spawn(char* binaryPath,
                   char** args,
                   struct Allocator* alloc,
@@ -26,7 +31,7 @@ int Process_spawn(char* binaryPath,
     int i;
     for (i = 0; args[i]; i++) ;
 
-    return Rffi_spawn(binaryPath, args, i, alloc, callback);
+    return Rffi_spawn(binaryPath, args, i, alloc, Process_OnExitCallbackWrapper);
 }
 
 char* Process_getPath(struct Allocator* alloc)


### PR DESCRIPTION
While [upgrading rust to the latest release](https://github.com/Homebrew/homebrew-core/pull/166865), saw the incompatible pointer type issue when building against latest xcode.

```
util/events/libuv/Process.c:29:51: error: incompatible function pointer types passing 'Process_OnExitCallback' (aka 'void (*)(long long, int)') to parameter of type 'void (*)(long, int)' [-Wincompatible-function-pointer-types]
    return Rffi_spawn(binaryPath, args, i, alloc, callback);
                                                  ^~~~~~~~
./rust/cjdns_sys/Rffi.h:127:27: note: passing argument to parameter 'cb' here
                   void (*cb)(long, int));
                          ^
```