### PR TITLE
Use portable type for char

### DIFF
--- a/rust/cjdns_sys/src/crypto/crypto_auth.rs
+++ b/rust/cjdns_sys/src/crypto/crypto_auth.rs
@@ -1940,7 +1940,7 @@ mod tests {
             };
 
             let res = unsafe {
-                let name = cffi::String_new(name.as_ptr() as *const i8, alloc);
+                let name = cffi::String_new(name.as_ptr() as *const std::os::raw::c_char, alloc);
                 cffi::CryptoAuth_addUser_ipv6(name, name, std::ptr::null_mut(), ca)
             };
             assert_eq!(res, 0, "CryptoAuth_addUser_ipv6() failed: {}", res);
@@ -1951,7 +1951,7 @@ mod tests {
                     alloc,
                     pub_key.as_ptr(),
                     false,
-                    format!("{}'s session", name).as_mut_ptr() as *mut i8,
+                    format!("{}'s session", name).as_mut_ptr() as *mut std::os::raw::c_char,
                     false,
                 )
             }
@@ -1992,7 +1992,7 @@ mod tests {
             };
 
             let res = unsafe {
-                let name = cffi::String_new(name.as_ptr() as *const i8, alloc);
+                let name = cffi::String_new(name.as_ptr() as *const std::os::raw::c_char, alloc);
                 cffi::CryptoAuth_addUser_ipv6(name, name, std::ptr::null_mut(), ca)
             };
             assert_eq!(res, 0, "CryptoAuth_addUser_ipv6() failed: {}", res);
@@ -2003,7 +2003,7 @@ mod tests {
                     alloc,
                     pub_key.as_ptr(),
                     false,
-                    format!("{}'s session", name).as_mut_ptr() as *mut i8,
+                    format!("{}'s session", name).as_mut_ptr() as *mut std::os::raw::c_char,
                     false,
                 )
             }

--- a/rust/cjdns_sys/src/interface/wire/message.rs
+++ b/rust/cjdns_sys/src/interface/wire/message.rs
@@ -371,7 +371,7 @@ mod tests {
         use crate::cffi::Allocator;
 
         pub(super) fn new_allocator(size_limit: u64) -> *mut Allocator {
-            unsafe { crate::cffi::MallocAllocator__new(size_limit, "".as_ptr() as *const i8, 0) }
+            unsafe { crate::cffi::MallocAllocator__new(size_limit, "".as_ptr() as *const std::os::raw::c_char, 0) }
         }
     }
 


### PR DESCRIPTION
There is a minor portability issue caused by implicitly assuming char pointers to be signed that causes problems on arm in some instances.

The function signatures of called functions correctly use portable `::std::os::raw::c_char` pointers (e.g., `String_new` in `cjdns_sys/src/cffi.rs`). However, the code calling those functions uses signed integer pointers, which affects portability: by default, char on x86 is signed while on arm it is unsigned. While this default can be changed via compiler flags, some build environments preclude such changes. One example would be Nix, where the build environment enforces reproducibilty; I'm sure there's others.

The problem is easily fixed by making the calling code use portable `::std::os::raw::c_char` pointers as well.

Build log on NixOS/aarch64:
```
Compiling cjdns_sys v0.1.0 (/build/source/rust/cjdns_sys)
warning: `cjdns_sys` (lib) generated 1 warning (run `cargo fix --lib -p cjdns_sys` to apply 1 suggestion)
error[E0308]: mismatched types
   --> rust/cjdns_sys/src/interface/wire/message.rs:374:68
    |
374 |             unsafe { crate::cffi::MallocAllocator__new(size_limit, "".as_ptr() as *const i8, 0) }
    |                      ---------------------------------             ^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
    |                      |
    |                      arguments to this function are incorrect
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
note: function defined here
   --> rust/cjdns_sys/src/cffi.rs:245:12
    |
245 |     pub fn MallocAllocator__new(
    |            ^^^^^^^^^^^^^^^^^^^^
 
error[E0308]: mismatched types
    --> rust/cjdns_sys/src/crypto/crypto_auth.rs:1943:45
     |
1943 |                 let name = cffi::String_new(name.as_ptr() as *const i8, alloc);
     |                            ---------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
     |                            |
     |                            arguments to this function are incorrect
     |
     = note: expected raw pointer `*const u8`
                found raw pointer `*const i8`
note: function defined here
    --> rust/cjdns_sys/src/cffi.rs:219:12
     |
219  |     pub fn String_new(
     |            ^^^^^^^^^^
 
error[E0308]: mismatched types
    --> rust/cjdns_sys/src/crypto/crypto_auth.rs:1954:21
     |
1949 |                 cffi::CryptoAuth_newSession(
     |                 --------------------------- arguments to this function are incorrect
...
1954 |                     format!("{}'s session", name).as_mut_ptr() as *mut i8,
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*mut i8`
     |
     = note: expected raw pointer `*const u8`
                found raw pointer `*mut i8`
note: function defined here
    --> rust/cjdns_sys/src/cffi.rs:544:12
     |
544  |     pub fn CryptoAuth_newSession(
     |            ^^^^^^^^^^^^^^^^^^^^^
 
error[E0308]: mismatched types
    --> rust/cjdns_sys/src/crypto/crypto_auth.rs:1995:45
     |
1995 |                 let name = cffi::String_new(name.as_ptr() as *const i8, alloc);
     |                            ---------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
     |                            |
     |                            arguments to this function are incorrect
     |
     = note: expected raw pointer `*const u8`
                found raw pointer `*const i8`
note: function defined here
    --> rust/cjdns_sys/src/cffi.rs:219:12
     |
219  |     pub fn String_new(
     |            ^^^^^^^^^^
 
error[E0308]: mismatched types
    --> rust/cjdns_sys/src/crypto/crypto_auth.rs:2006:21
     |
2001 |                 cffi::CryptoAuth_newSession(
     |                 --------------------------- arguments to this function are incorrect
...
2006 |                     format!("{}'s session", name).as_mut_ptr() as *mut i8,
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*mut i8`
     |
     = note: expected raw pointer `*const u8`
                found raw pointer `*mut i8`
note: function defined here
    --> rust/cjdns_sys/src/cffi.rs:544:12
     |
544  |     pub fn CryptoAuth_newSession(
     |            ^^^^^^^^^^^^^^^^^^^^^
 
For more information about this error, try `rustc --explain E0308`.
error: could not compile `cjdns_sys` (lib test) due to 5 previous errors
warning: build failed, waiting for other jobs to finish...
```