### PR TITLE
Print error if cargo is not found

### DIFF
--- a/do
+++ b/do
@@ -2,9 +2,8 @@
 
 set -e
 export PATH="$HOME/.cargo/bin:$PATH"
-CARGO="$(command -v cargo)"
 
-if [ -z "$CARGO" ]; then
+if ! CARGO="$(command -v cargo)"; then
     printf "Rust & Cargo are required in order to build cjdns\n"
     printf "See https://rustup.rs/ for install instructions\n"
     exit 1


### PR DESCRIPTION
Update build script to explicitly print error, if cargo is not found. Before, it fails silently and it was harder to troubleshoot it. I was trying to compile the latest cjdns version to OpenWrt, but it fails without saying anything.

### Before:
```
(cd /Volumes/OpenWrt/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/cjdns-cjdns-v22.1 && CROSS="true" CC="arm-openwrt-linux-muslgnueabi-gcc" AR="arm-openwrt-linux-muslgnueabi-gcc-ar" RANLIB="arm-openwrt-linux-muslgnueabi-gcc-ranlib" CFLAGS="-Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -mfloat-abi=hard -fmacro-prefix-map=/Volumes/OpenWrt/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/cjdns-cjdns-v22.1=cjdns-cjdns-v22.1 -Wformat -Werror=format-security -DPIC -fpic -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wl,-z,now -Wl,-z,relro -U_FORTIFY_SOURCE -Wno-error=array-bounds -Wno-error=stringop-overflow -Wno-error=stringop-overread" LDFLAGS="-L/Volumes/OpenWrt/omnia-hbd/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-13.3.0_musl_eabi/usr/lib -L/Volumes/OpenWrt/omnia-hbd/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-13.3.0_musl_eabi/lib -fuse-ld=bfd -DPIC -fpic -specs=/Volumes/OpenWrt/omnia-hbd/build/include/hardened-ld-pie.specs -znow -zrelro" SYSTEM="linux" TARGET_ARCH=""arm"" SSP_SUPPORT="y" GYP_ADDITIONAL_ARGS="-f make-linux" CJDNS_BUILD_TMPDIR="/Volumes/OpenWrt/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/cjdns-cjdns-v22.1/tmp" CJDNS_RELEASE_VERSION= exec ./do)
make[2]: *** [Makefile:154: /Volumes/OpenWrt/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/cjdns-cjdns-v22.1/.built] Error 1
make[2]: Leaving directory '/Volumes/OpenWrt/omnia-hbd/build/feeds/routing/cjdns'
```

Then I try to run ``./do`` manually and it didnt print anything. I run ``command -v cargo`` manually and it does not print anything, because I did not have installed cargo by running ``which cargo``, it says that cargo is not found.


### After applying this fix:
```
./do
Rust & Cargo are required in order to build cjdns
See https://rustup.rs/ for install instructions
```

And as well it prints something while building cjdns for OpenWrt:
```
(cd /Volumes/OpenWrt/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/cjdns-cjdns-v22.1 && CROSS="true" CC="arm-openwrt-linux-muslgnueabi-gcc" AR="arm-openwrt-linux-muslgnueabi-gcc-ar" RANLIB="arm-openwrt-linux-muslgnueabi-gcc-ranlib" CFLAGS="-Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -mfloat-abi=hard -fmacro-prefix-map=/Volumes/OpenWrt/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/cjdns-cjdns-v22.1=cjdns-cjdns-v22.1 -Wformat -Werror=format-security -DPIC -fpic -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wl,-z,now -Wl,-z,relro -U_FORTIFY_SOURCE -Wno-error=array-bounds -Wno-error=stringop-overflow -Wno-error=stringop-overread" LDFLAGS="-L/Volumes/OpenWrt/omnia-hbd/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-13.3.0_musl_eabi/usr/lib -L/Volumes/OpenWrt/omnia-hbd/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-13.3.0_musl_eabi/lib -fuse-ld=bfd -DPIC -fpic -specs=/Volumes/OpenWrt/omnia-hbd/build/include/hardened-ld-pie.specs -znow -zrelro" SYSTEM="linux" TARGET_ARCH=""arm"" SSP_SUPPORT="y" GYP_ADDITIONAL_ARGS="-f make-linux" CJDNS_BUILD_TMPDIR="/Volumes/OpenWrt/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/cjdns-cjdns-v22.1/tmp" CJDNS_RELEASE_VERSION= exec ./do)
Rust & Cargo are required in order to build cjdns
See https://rustup.rs/ for install instructions
make[2]: *** [Makefile:154: /Volumes/OpenWrt/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/cjdns-cjdns-v22.1/.built] Error 1
```