### PR TITLE
fix(rffi): remove implicit autoref on raw pointers and clarify lifetime

### DIFF
--- a/rust/cjdns_sys/src/rffi/allocator.rs
+++ b/rust/cjdns_sys/src/rffi/allocator.rs
@@ -217,9 +217,11 @@ impl Allocator {
         // This "as" does not cast, but it fails if we're wrong
         let a = Box::into_raw(a);
         unsafe {
-            (*a).inner.ident.replace(format!("{}/{:p}", file_line.print(), a));
-            (*a).inner.mebox.replace(a);
-            log::trace!("New allocator {} <- {}", (*a).ident(), parent);
+            // Avoid creating implicit references from raw pointer field chaining; take an explicit ref.
+            let alloc_ref: &mut Allocator = &mut *a;
+            alloc_ref.inner.ident.replace(format!("{}/{:p}", file_line.print(), a));
+            alloc_ref.inner.mebox.replace(a);
+            log::trace!("New allocator {} <- {}", alloc_ref.ident(), parent);
         }
         a as *mut Allocator_t
     }
@@ -234,7 +236,7 @@ impl Allocator {
         Self::new_int(file_line, Vec::new())
     }
 
-    pub fn ident(&self) -> Ref<String> {
+    pub fn ident(&self) -> Ref<'_, String> {
         self.inner.ident.borrow()
     }
 

--- a/rust/cjdns_sys/src/rffi/benc.rs
+++ b/rust/cjdns_sys/src/rffi/benc.rs
@@ -51,7 +51,11 @@ pub fn string_to_c<'a>(alloc: *mut Allocator_t, v: impl Into<&'a[u8]>) -> *mut S
     let len = v.len();
     v.push(0);
     let bytes = allocator::adopt(alloc, v);
-    let bytes = unsafe { (*bytes)[..].as_mut_ptr() };
+    // Avoid implicit autoref of raw pointer (*bytes) by taking an explicit mutable reference first
+    let bytes = unsafe {
+        let v_ref: &mut Vec<u8> = &mut *bytes;
+        v_ref.as_mut_ptr()
+    };
     allocator::adopt(alloc, String_t{
         len,
         bytes: bytes as _,


### PR DESCRIPTION
seeing some build failure against rust 1.89.0

```
  error: implicit autoref creates a reference to the dereference of a raw pointer
     --> rust/cjdns_sys/src/rffi/allocator.rs:220:13
      |
  220 |             (*a).inner.ident.replace(format!("{}/{:p}", file_line.print(), a));
      |             ^^-^^^^^^^^^^^^^
      |               |
      |               this raw pointer has type `*mut allocator::Allocator`
      |
      = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
      = note: references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
      = note: `#[deny(dangerous_implicit_autorefs)]` on by default
  help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
      |
  220 |             (&(*a).inner).ident.replace(format!("{}/{:p}", file_line.print(), a));
      |             ++          +
      
error: implicit autoref creates a reference to the dereference of a raw pointer
  --> rust/cjdns_sys/src/rffi/benc.rs:54:26
   |
54 |     let bytes = unsafe { (*bytes)[..].as_mut_ptr() };
   |                          ^^-----^^^^^
   |                            |
   |                            this raw pointer has type `*mut Vec<u8>`
   |
   = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
```